### PR TITLE
Fix Anthropic credential test using wrong model ID

### DIFF
--- a/platform/api/credentials.py
+++ b/platform/api/credentials.py
@@ -265,7 +265,7 @@ def test_credential(
                     "content-type": "application/json",
                 },
                 json={
-                    "model": "claude-haiku-3-5-20241022",
+                    "model": "claude-3-5-haiku-20241022",
                     "max_tokens": 1,
                     "messages": [{"role": "user", "content": "hi"}],
                 },


### PR DESCRIPTION
claude-haiku-3-5-20241022 → claude-3-5-haiku-20241022. The typo caused Anthropic to return 400, making the test report failure despite valid key.