### PR TITLE
Fix run_command subprocess stops in RQ workers

### DIFF
--- a/platform/components/run_command.py
+++ b/platform/components/run_command.py
@@ -8,10 +8,16 @@ from langchain_core.tools import tool
 
 from components import register
 
+_DEFAULT_TIMEOUT = 300  # seconds
+_MAX_OUTPUT_CHARS = 50_000
+
 
 @register("run_command")
 def run_command_factory(node):
     """Return a LangChain tool that runs shell commands."""
+
+    extra = node.component_config.extra_config or {}
+    timeout = int(extra.get("timeout", _DEFAULT_TIMEOUT))
 
     @tool
     def run_command(command: str) -> str:
@@ -22,16 +28,26 @@ def run_command_factory(node):
                 shell=True,
                 capture_output=True,
                 text=True,
-                timeout=60,
+                timeout=timeout,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
             )
             output = result.stdout
             if result.stderr:
                 output += f"\nSTDERR:\n{result.stderr}"
             if result.returncode != 0:
                 output += f"\n[exit code: {result.returncode}]"
-            return output or "(no output)"
+            output = output or "(no output)"
+            if len(output) > _MAX_OUTPUT_CHARS:
+                half = _MAX_OUTPUT_CHARS // 2
+                output = (
+                    output[:half]
+                    + f"\n\n... ({len(output) - _MAX_OUTPUT_CHARS} chars truncated) ...\n\n"
+                    + output[-half:]
+                )
+            return output
         except subprocess.TimeoutExpired:
-            return "Error: command timed out after 60 seconds"
+            return f"Error: command timed out after {timeout} seconds"
         except Exception as e:
             return f"Error: {e}"
 

--- a/platform/services/orchestrator.py
+++ b/platform/services/orchestrator.py
@@ -30,7 +30,7 @@ def _redis() -> redis_lib.Redis:
 
 def _queue() -> Queue:
     conn = redis_lib.from_url(settings.REDIS_URL)
-    return Queue("workflows", connection=conn)
+    return Queue("workflows", connection=conn, default_timeout=600)
 
 
 # ── Redis state helpers ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fixes `claude -p` and other commands getting suspended (SIGTTIN/SIGTTOU) when spawned via `run_command` inside RQ worker subprocesses
- Adds `stdin=DEVNULL` and `start_new_session=True` to isolate subprocess from parent TTY
- Increases default timeout from 60s to 300s (configurable via `extra_config.timeout`)
- Adds output truncation at 50K chars to prevent OOM on large command outputs
- Increases RQ workflows queue `default_timeout` to 600s

## Test plan
- [x] All 6 existing `TestRunCommand` tests pass
- [ ] Verify `claude -p` no longer gets stopped when invoked by orchestrator agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)