### PR TITLE
feat: zombie execution detection and recovery (phase 2)

### DIFF
--- a/platform/config.py
+++ b/platform/config.py
@@ -28,6 +28,8 @@ class Settings(BaseSettings):
 
     CORS_ALLOW_ALL_ORIGINS: bool = True
 
+    ZOMBIE_EXECUTION_THRESHOLD_SECONDS: int = 900  # 15 min
+
     model_config = ConfigDict(
         env_file=str(BASE_DIR.parent / ".env"),
         env_file_encoding="utf-8",

--- a/platform/main.py
+++ b/platform/main.py
@@ -40,6 +40,21 @@ async def lifespan(app: FastAPI):
         import logging
         logging.getLogger(__name__).exception("Failed to recover scheduled jobs on startup")
 
+    # Recover any executions stuck in "running" from a previous crash
+    try:
+        from services.execution_recovery import recover_zombie_executions
+        recovered_executions = recover_zombie_executions()
+        if recovered_executions:
+            import logging
+            logging.getLogger(__name__).info(
+                "Recovered %d zombie executions", recovered_executions
+            )
+    except Exception:
+        import logging
+        logging.getLogger(__name__).exception(
+            "Failed to recover zombie executions on startup"
+        )
+
     yield
 
 

--- a/platform/services/execution_recovery.py
+++ b/platform/services/execution_recovery.py
@@ -1,0 +1,153 @@
+"""Detect and recover zombie executions stuck in 'running' state.
+
+A zombie execution is one whose RQ worker crashed (OOM, host reboot, etc.)
+leaving the DB row in ``status='running'`` with no worker to finish it.
+
+Two entry points:
+
+- ``recover_zombie_executions()`` — called on server startup (mirrors
+  ``recover_scheduled_jobs()`` in ``services/scheduler.py``)
+- ``recover_zombie_executions_job()`` in ``tasks/__init__.py`` — periodic
+  RQ watchdog (mirrors ``cleanup_stuck_child_waits_job()``)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+
+import redis as redis_lib
+from sqlalchemy.orm import Session
+
+from config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def recover_zombie_executions(threshold_seconds: int | None = None) -> int:
+    """Find and recover all zombie executions.
+
+    An execution is considered a zombie when:
+    - ``status == 'running'``
+    - ``started_at`` is older than *threshold_seconds* ago
+
+    Each zombie is marked ``failed`` with an explanatory error message,
+    a WebSocket event is published, and its Redis keys are cleaned up.
+
+    Returns the number of executions recovered.
+    """
+    from database import SessionLocal
+    from models.execution import WorkflowExecution
+
+    if threshold_seconds is None:
+        threshold_seconds = settings.ZOMBIE_EXECUTION_THRESHOLD_SECONDS
+
+    db: Session = SessionLocal()
+    try:
+        cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - _timedelta(threshold_seconds)
+        zombies = (
+            db.query(WorkflowExecution)
+            .filter(
+                WorkflowExecution.status == "running",
+                WorkflowExecution.started_at < cutoff,
+            )
+            .all()
+        )
+        if not zombies:
+            return 0
+
+        recovered = 0
+        for execution in zombies:
+            try:
+                _recover_one(execution, db)
+                recovered += 1
+            except Exception:
+                logger.exception(
+                    "Failed to recover zombie execution %s", execution.execution_id,
+                )
+        return recovered
+    except Exception:
+        logger.exception("Error in recover_zombie_executions")
+        return 0
+    finally:
+        db.close()
+
+
+def _recover_one(execution, db: Session) -> None:
+    """Mark a single zombie execution as failed and clean up."""
+    from models.workflow import Workflow
+
+    execution_id = execution.execution_id
+    logger.warning("Recovering zombie execution %s", execution_id)
+
+    execution.status = "failed"
+    execution.error_message = (
+        "Execution recovered as failed: worker presumed crashed "
+        "(exceeded zombie threshold)"
+    )
+    execution.completed_at = datetime.now(timezone.utc)
+    db.commit()
+
+    # Look up workflow slug for the WS event (best-effort)
+    workflow_slug = None
+    try:
+        wf = db.query(Workflow).filter(Workflow.id == execution.workflow_id).first()
+        if wf:
+            workflow_slug = wf.slug
+    except Exception:
+        pass
+
+    _publish_zombie_event(execution_id, workflow_slug)
+    _cleanup_redis(execution_id)
+
+
+def _publish_zombie_event(execution_id: str, workflow_slug: str | None) -> None:
+    """Publish an ``execution_failed`` event via Redis pub/sub (best-effort)."""
+    try:
+        r = redis_lib.from_url(settings.REDIS_URL, decode_responses=True)
+        try:
+            payload = {
+                "type": "execution_failed",
+                "execution_id": execution_id,
+                "timestamp": time.time(),
+                "data": {"error": "Execution recovered as failed (zombie)"},
+            }
+            raw = json.dumps(payload)
+            r.publish(f"execution:{execution_id}", raw)
+            if workflow_slug:
+                payload["channel"] = f"workflow:{workflow_slug}"
+                r.publish(f"workflow:{workflow_slug}", json.dumps(payload))
+        finally:
+            r.close()
+    except Exception:
+        logger.warning(
+            "Failed to publish zombie event for execution %s (non-fatal)",
+            execution_id,
+            exc_info=True,
+        )
+
+
+def _cleanup_redis(execution_id: str) -> None:
+    """Delete ``execution:{id}:*`` keys from Redis (best-effort)."""
+    try:
+        r = redis_lib.from_url(settings.REDIS_URL, decode_responses=True)
+        try:
+            keys = r.keys(f"execution:{execution_id}:*")
+            if keys:
+                r.delete(*keys)
+        finally:
+            r.close()
+    except Exception:
+        logger.warning(
+            "Failed to clean up Redis keys for execution %s (non-fatal)",
+            execution_id,
+            exc_info=True,
+        )
+
+
+def _timedelta(seconds: int):
+    """Helper to avoid import at module top level for tests."""
+    from datetime import timedelta
+    return timedelta(seconds=seconds)

--- a/platform/tasks/__init__.py
+++ b/platform/tasks/__init__.py
@@ -36,3 +36,8 @@ def cleanup_stuck_child_waits_job() -> int:
 def execute_scheduled_job_task(job_id: str, current_repeat: int = 0, current_retry: int = 0) -> None:
     from services.scheduler import execute_scheduled_job
     execute_scheduled_job(job_id, current_repeat, current_retry)
+
+
+def recover_zombie_executions_job() -> int:
+    from services.execution_recovery import recover_zombie_executions
+    return recover_zombie_executions()

--- a/platform/tests/test_execution_recovery.py
+++ b/platform/tests/test_execution_recovery.py
@@ -1,0 +1,346 @@
+"""Tests for zombie execution detection and recovery."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+_platform_dir = str(Path(__file__).resolve().parent.parent)
+if _platform_dir not in sys.path:
+    sys.path.insert(0, _platform_dir)
+
+from models.execution import WorkflowExecution
+from services.execution_recovery import (
+    recover_zombie_executions,
+    _recover_one,
+    _publish_zombie_event,
+    _cleanup_redis,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _utcnow_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def _make_execution(db, workflow, user_profile, *, status="running", started_at=None):
+    """Create a WorkflowExecution with the given status and started_at."""
+    ex = WorkflowExecution(
+        workflow_id=workflow.id,
+        user_profile_id=user_profile.id,
+        thread_id="test-thread",
+        status=status,
+        started_at=started_at,
+    )
+    db.add(ex)
+    db.commit()
+    db.refresh(ex)
+    return ex
+
+
+def _nonclosing_session(db):
+    """Return a mock SessionLocal that yields db but whose close() is a no-op."""
+    mock_session = MagicMock(wraps=db)
+    mock_session.close = MagicMock()  # no-op close so test session stays open
+    return mock_session
+
+
+def _patch_session(db):
+    """Patch database.SessionLocal to return a non-closing wrapper around db."""
+    return patch("database.SessionLocal", return_value=_nonclosing_session(db))
+
+
+# ---------------------------------------------------------------------------
+# Core recovery tests
+# ---------------------------------------------------------------------------
+
+class TestRecoverZombieExecutions:
+    """Tests for the top-level recover_zombie_executions() function."""
+
+    @patch("services.execution_recovery._cleanup_redis")
+    @patch("services.execution_recovery._publish_zombie_event")
+    def test_stale_running_execution_recovered(self, mock_pub, mock_redis, db, workflow, user_profile):
+        """A running execution older than the threshold is recovered."""
+        ex = _make_execution(
+            db, workflow, user_profile,
+            status="running",
+            started_at=_utcnow_naive() - timedelta(seconds=2000),
+        )
+
+        with _patch_session(db):
+            count = recover_zombie_executions(threshold_seconds=900)
+
+        assert count == 1
+        db.refresh(ex)
+        assert ex.status == "failed"
+        assert "zombie" in ex.error_message.lower()
+        assert ex.completed_at is not None
+
+    @patch("services.execution_recovery._cleanup_redis")
+    @patch("services.execution_recovery._publish_zombie_event")
+    def test_recent_running_execution_not_recovered(self, mock_pub, mock_redis, db, workflow, user_profile):
+        """A running execution younger than the threshold is left alone."""
+        ex = _make_execution(
+            db, workflow, user_profile,
+            status="running",
+            started_at=_utcnow_naive() - timedelta(seconds=60),
+        )
+
+        with _patch_session(db):
+            count = recover_zombie_executions(threshold_seconds=900)
+
+        assert count == 0
+        db.refresh(ex)
+        assert ex.status == "running"
+
+    @patch("services.execution_recovery._cleanup_redis")
+    @patch("services.execution_recovery._publish_zombie_event")
+    def test_non_running_executions_ignored(self, mock_pub, mock_redis, db, workflow, user_profile):
+        """Completed, failed, and pending executions are never touched."""
+        old = _utcnow_naive() - timedelta(seconds=2000)
+        for status in ("completed", "failed", "pending"):
+            _make_execution(db, workflow, user_profile, status=status, started_at=old)
+
+        with _patch_session(db):
+            count = recover_zombie_executions(threshold_seconds=900)
+
+        assert count == 0
+
+    @patch("services.execution_recovery._cleanup_redis")
+    @patch("services.execution_recovery._publish_zombie_event")
+    def test_multiple_zombies_all_recovered(self, mock_pub, mock_redis, db, workflow, user_profile):
+        """All stale running executions are recovered in one call."""
+        old = _utcnow_naive() - timedelta(seconds=2000)
+        execs = [
+            _make_execution(db, workflow, user_profile, status="running", started_at=old)
+            for _ in range(3)
+        ]
+
+        with _patch_session(db):
+            count = recover_zombie_executions(threshold_seconds=900)
+
+        assert count == 3
+        for ex in execs:
+            db.refresh(ex)
+            assert ex.status == "failed"
+
+    @patch("services.execution_recovery._cleanup_redis")
+    @patch("services.execution_recovery._publish_zombie_event")
+    def test_partial_failure_continues(self, mock_pub, mock_redis, db, workflow, user_profile):
+        """If one recovery fails, the others still succeed."""
+        old = _utcnow_naive() - timedelta(seconds=2000)
+        ex1 = _make_execution(db, workflow, user_profile, status="running", started_at=old)
+        ex2 = _make_execution(db, workflow, user_profile, status="running", started_at=old)
+
+        call_count = 0
+        original_recover_one = _recover_one
+
+        def _flaky_recover(execution, sess):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("Simulated failure")
+            original_recover_one(execution, sess)
+
+        with (
+            _patch_session(db),
+            patch("services.execution_recovery._recover_one", side_effect=_flaky_recover),
+        ):
+            count = recover_zombie_executions(threshold_seconds=900)
+
+        # One succeeded, one failed
+        assert count == 1
+
+    @patch("services.execution_recovery._cleanup_redis")
+    @patch("services.execution_recovery._publish_zombie_event")
+    def test_custom_threshold(self, mock_pub, mock_redis, db, workflow, user_profile):
+        """A custom threshold_seconds parameter is respected."""
+        ex = _make_execution(
+            db, workflow, user_profile,
+            status="running",
+            started_at=_utcnow_naive() - timedelta(seconds=120),
+        )
+
+        # With 60s threshold, execution at 120s ago is stale
+        with _patch_session(db):
+            count = recover_zombie_executions(threshold_seconds=60)
+        assert count == 1
+
+        # Reset
+        ex.status = "running"
+        ex.completed_at = None
+        ex.error_message = ""
+        ex.started_at = _utcnow_naive() - timedelta(seconds=120)
+        db.commit()
+
+        # With 300s threshold, same execution is not stale
+        with _patch_session(db):
+            count2 = recover_zombie_executions(threshold_seconds=300)
+        assert count2 == 0
+
+    @patch("services.execution_recovery._cleanup_redis")
+    @patch("services.execution_recovery._publish_zombie_event")
+    def test_no_zombies_returns_zero(self, mock_pub, mock_redis, db, workflow, user_profile):
+        """Returns 0 when there are no zombie executions."""
+        with _patch_session(db):
+            count = recover_zombie_executions(threshold_seconds=900)
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# _recover_one tests
+# ---------------------------------------------------------------------------
+
+class TestRecoverOne:
+    """Tests for the per-execution recovery helper."""
+
+    @patch("services.execution_recovery._cleanup_redis")
+    @patch("services.execution_recovery._publish_zombie_event")
+    def test_sets_status_and_fields(self, mock_pub, mock_redis, db, workflow, user_profile):
+        """_recover_one sets status, error_message, and completed_at."""
+        ex = _make_execution(
+            db, workflow, user_profile,
+            status="running",
+            started_at=_utcnow_naive() - timedelta(seconds=2000),
+        )
+        _recover_one(ex, db)
+
+        db.refresh(ex)
+        assert ex.status == "failed"
+        assert "zombie" in ex.error_message.lower()
+        assert ex.completed_at is not None
+
+    @patch("services.execution_recovery._cleanup_redis")
+    @patch("services.execution_recovery._publish_zombie_event")
+    def test_publishes_ws_event(self, mock_pub, mock_redis, db, workflow, user_profile):
+        """_recover_one publishes a WS event with the workflow slug."""
+        ex = _make_execution(
+            db, workflow, user_profile,
+            status="running",
+            started_at=_utcnow_naive() - timedelta(seconds=2000),
+        )
+        _recover_one(ex, db)
+
+        mock_pub.assert_called_once_with(ex.execution_id, workflow.slug)
+
+    @patch("services.execution_recovery._cleanup_redis")
+    @patch("services.execution_recovery._publish_zombie_event")
+    def test_cleans_up_redis(self, mock_pub, mock_redis, db, workflow, user_profile):
+        """_recover_one calls _cleanup_redis for the execution."""
+        ex = _make_execution(
+            db, workflow, user_profile,
+            status="running",
+            started_at=_utcnow_naive() - timedelta(seconds=2000),
+        )
+        _recover_one(ex, db)
+
+        mock_redis.assert_called_once_with(ex.execution_id)
+
+
+# ---------------------------------------------------------------------------
+# _publish_zombie_event tests
+# ---------------------------------------------------------------------------
+
+class TestPublishZombieEvent:
+    """Tests for best-effort WS event publishing."""
+
+    @patch("services.execution_recovery.redis_lib")
+    def test_publishes_to_execution_channel(self, mock_redis_mod):
+        """Event is published to execution:<id> channel."""
+        mock_r = MagicMock()
+        mock_redis_mod.from_url.return_value = mock_r
+
+        _publish_zombie_event("exec-123", None)
+
+        mock_r.publish.assert_called_once()
+        channel = mock_r.publish.call_args[0][0]
+        assert channel == "execution:exec-123"
+
+    @patch("services.execution_recovery.redis_lib")
+    def test_publishes_to_workflow_channel(self, mock_redis_mod):
+        """Event is also published to workflow:<slug> when slug is provided."""
+        mock_r = MagicMock()
+        mock_redis_mod.from_url.return_value = mock_r
+
+        _publish_zombie_event("exec-123", "my-workflow")
+
+        assert mock_r.publish.call_count == 2
+        channels = [c[0][0] for c in mock_r.publish.call_args_list]
+        assert "execution:exec-123" in channels
+        assert "workflow:my-workflow" in channels
+
+    @patch("services.execution_recovery.redis_lib")
+    def test_redis_failure_does_not_raise(self, mock_redis_mod):
+        """Redis errors are swallowed (best-effort)."""
+        mock_redis_mod.from_url.side_effect = ConnectionError("Redis down")
+
+        # Should not raise
+        _publish_zombie_event("exec-123", "slug")
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_redis tests
+# ---------------------------------------------------------------------------
+
+class TestCleanupRedis:
+    """Tests for best-effort Redis key cleanup."""
+
+    @patch("services.execution_recovery.redis_lib")
+    def test_deletes_matching_keys(self, mock_redis_mod):
+        """All execution:*:* keys are deleted."""
+        mock_r = MagicMock()
+        mock_redis_mod.from_url.return_value = mock_r
+        mock_r.keys.return_value = [
+            "execution:abc:state",
+            "execution:abc:topo",
+            "execution:abc:inflight",
+        ]
+
+        _cleanup_redis("abc")
+
+        mock_r.delete.assert_called_once_with(
+            "execution:abc:state",
+            "execution:abc:topo",
+            "execution:abc:inflight",
+        )
+
+    @patch("services.execution_recovery.redis_lib")
+    def test_no_keys_no_delete(self, mock_redis_mod):
+        """No delete call when there are no matching keys."""
+        mock_r = MagicMock()
+        mock_redis_mod.from_url.return_value = mock_r
+        mock_r.keys.return_value = []
+
+        _cleanup_redis("abc")
+
+        mock_r.delete.assert_not_called()
+
+    @patch("services.execution_recovery.redis_lib")
+    def test_redis_failure_does_not_raise(self, mock_redis_mod):
+        """Redis errors are swallowed (best-effort)."""
+        mock_redis_mod.from_url.side_effect = ConnectionError("Redis down")
+
+        # Should not raise
+        _cleanup_redis("abc")
+
+
+# ---------------------------------------------------------------------------
+# RQ task wrapper test
+# ---------------------------------------------------------------------------
+
+class TestRQTaskWrapper:
+    """Test that the tasks module wrapper delegates correctly."""
+
+    @patch("services.execution_recovery.recover_zombie_executions", return_value=5)
+    def test_task_wrapper_delegates(self, mock_recover):
+        from tasks import recover_zombie_executions_job
+        result = recover_zombie_executions_job()
+        assert result == 5
+        mock_recover.assert_called_once()


### PR DESCRIPTION
## Summary

- Add startup recovery that marks stale `running` executions as `failed` on server boot (mirrors `recover_scheduled_jobs()` pattern)
- Add periodic RQ watchdog task wrapper (`recover_zombie_executions_job`) for runtime detection (mirrors `cleanup_stuck_child_waits_job()` pattern)
- Core logic in `services/execution_recovery.py`: per-execution DB update, WebSocket event publishing, Redis key cleanup — all best-effort with per-execution error isolation
- Configurable threshold via `ZOMBIE_EXECUTION_THRESHOLD_SECONDS` env var (default 900s / 15 min)

## Files changed

| File | Change |
|------|--------|
| `platform/config.py` | Add `ZOMBIE_EXECUTION_THRESHOLD_SECONDS` setting |
| `platform/services/execution_recovery.py` | New — core recovery logic |
| `platform/tasks/__init__.py` | Add `recover_zombie_executions_job()` RQ wrapper |
| `platform/main.py` | Call recovery on startup in `lifespan()` |
| `platform/tests/test_execution_recovery.py` | 17 tests |

## Test plan

- [x] 17 new tests all pass (`pytest tests/test_execution_recovery.py -v`)
- [x] Full test suite regression check — no new failures
- [ ] Manual: restart server with a stale `running` execution in DB, verify it gets marked `failed`
- [ ] Manual: verify `recover_zombie_executions_job()` works when enqueued as periodic RQ task

🤖 Generated with [Claude Code](https://claude.com/claude-code)