### PR TITLE
fix: PopoutWindow StrictMode compatibility and Save persistence

### DIFF
--- a/platform/frontend/src/components/PopoutWindow.tsx
+++ b/platform/frontend/src/components/PopoutWindow.tsx
@@ -1,0 +1,90 @@
+import { createContext, useEffect, useRef, useState, type ReactNode } from "react"
+import { createPortal } from "react-dom"
+
+/** Context providing the popup document body so Radix portals (Popover, Dialog, etc.) render in the correct document. */
+export const PopoutContainerContext = createContext<HTMLElement | undefined>(undefined)
+
+interface PopoutWindowProps {
+  popupWindow: Window
+  title: string
+  onClose: () => void
+  children: ReactNode
+}
+
+export default function PopoutWindow({ popupWindow, title, onClose, children }: PopoutWindowProps) {
+  const [popoutRoot, setPopoutRoot] = useState<HTMLElement | null>(null)
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+
+  useEffect(() => {
+    const popup = popupWindow
+    if (popup.closed) return
+
+    const popupDoc = popup.document
+    const parentHead = document.head
+
+    // Idempotent setup — skip if already initialized (StrictMode re-mount)
+    let root = popupDoc.getElementById("popout-root") as HTMLElement | null
+    if (!root) {
+      popupDoc.title = title
+
+      // Copy stylesheets from parent into popup head
+      for (const node of Array.from(parentHead.querySelectorAll('style, link[rel="stylesheet"]'))) {
+        popupDoc.head.appendChild(node.cloneNode(true))
+      }
+
+      // Copy dark mode class from parent <html>
+      popupDoc.documentElement.className = document.documentElement.className
+
+      // Create root container in popup body
+      root = popupDoc.createElement("div")
+      root.id = "popout-root"
+      root.className = "bg-background text-foreground min-h-screen"
+      popupDoc.body.appendChild(root)
+    }
+    setPopoutRoot(root)
+
+    // Watch parent <head> for dynamically injected styles (CodeMirror, HMR)
+    const headObserver = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const added of Array.from(mutation.addedNodes)) {
+          if (added instanceof HTMLStyleElement || (added instanceof HTMLLinkElement && added.rel === "stylesheet")) {
+            popupDoc.head.appendChild(added.cloneNode(true))
+          }
+        }
+      }
+    })
+    headObserver.observe(parentHead, { childList: true })
+
+    // Watch parent <html> class for dark mode toggles
+    const htmlObserver = new MutationObserver(() => {
+      popupDoc.documentElement.className = document.documentElement.className
+    })
+    htmlObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] })
+
+    // Notify parent when user closes popup via browser X button
+    const handleUnload = () => onCloseRef.current()
+    popup.addEventListener("beforeunload", handleUnload)
+
+    // Close popup if parent page navigates away
+    const handlePageHide = () => { if (!popup.closed) popup.close() }
+    window.addEventListener("pagehide", handlePageHide)
+
+    return () => {
+      headObserver.disconnect()
+      htmlObserver.disconnect()
+      popup.removeEventListener("beforeunload", handleUnload)
+      window.removeEventListener("pagehide", handlePageHide)
+      // NO popup.close() here — parent manages popup lifecycle imperatively
+    }
+  }, [popupWindow, title])
+
+  if (!popoutRoot) return null
+
+  return createPortal(
+    <PopoutContainerContext.Provider value={popoutRoot}>
+      {children}
+    </PopoutContainerContext.Provider>,
+    popoutRoot,
+  )
+}


### PR DESCRIPTION
## Summary

- **Remove fragile `setTimeout`/`clearTimeout` StrictMode workaround** in `PopoutWindow` — popup lifecycle is now managed imperatively by the parent, not tied to `useEffect` cleanup
- **Popout Save buttons now persist to the database** — previously they only updated local state without calling `handleSave()`. Uses a `saveOnNextRender` ref to defer the save until after React state has settled.
- **Add `pagehide` listener** on parent window to close popups when the user navigates away
- **Add `closePopout()` helper** used by all Save/Cancel buttons to close the popup window before clearing state

## Test plan

- [x] Click "Pop Out" on any editor (System Prompt, Code, Extra Config, Chat) — popup stays open (no flash-close in dev mode)
- [x] Click Save in popup — popup closes, value updates in main panel AND persists to database
- [x] Click Cancel in popup — popup closes, no changes saved
- [x] Close popup via browser X button — parent state cleans up, no console errors
- [x] Navigate to a different page while popup is open — popup closes via `pagehide`
- [x] All above work identically in dev mode (StrictMode) and production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)