### PR TITLE
Fix editor modal UI polish

### DIFF
--- a/platform/frontend/src/components/CodeMirrorEditor.tsx
+++ b/platform/frontend/src/components/CodeMirrorEditor.tsx
@@ -70,6 +70,11 @@ export default function CodeMirrorEditor({
       }
     })
 
+    const fillHeightTheme = EditorView.theme({
+      "&": { height: "100%" },
+      ".cm-scroller": { overflow: "auto" },
+    })
+
     const extensions = [
       lineNumbers(),
       highlightActiveLineGutter(),
@@ -83,6 +88,7 @@ export default function CodeMirrorEditor({
       getLanguageExtension(language),
       jinja2Highlight,
       EditorView.lineWrapping,
+      fillHeightTheme,
       ...(isDark ? [oneDark] : []),
       ...(placeholder ? [cmPlaceholder(placeholder)] : []),
       ...(readOnly ? [EditorState.readOnly.of(true)] : []),

--- a/platform/frontend/src/components/CodeMirrorExpressionEditor.tsx
+++ b/platform/frontend/src/components/CodeMirrorExpressionEditor.tsx
@@ -64,7 +64,7 @@ export default function CodeMirrorExpressionEditor({
         onChange={onChange}
         language={language}
         placeholder={placeholder}
-        className={`flex-1 min-h-0 [&_.cm-editor]:h-full [&_.cm-scroller]:overflow-auto ${className}`}
+        className={`flex-1 min-h-0 h-0 ${className}`}
         readOnly={readOnly}
       />
     </div>

--- a/platform/frontend/src/features/workflows/components/NodeDetailsPanel.tsx
+++ b/platform/frontend/src/features/workflows/components/NodeDetailsPanel.tsx
@@ -981,71 +981,75 @@ function NodeConfigPanel({ slug, node, workflow, onClose }: Props) {
           )}
 
           <Dialog open={promptModalOpen} onOpenChange={setPromptModalOpen}>
-            <DialogContent className="max-w-[90vw] w-[1000px] h-[80vh] flex flex-col" showCloseButton={false}>
-              <DialogHeader>
-                <div className="flex items-center justify-between">
-                  <DialogTitle>Edit System Prompt</DialogTitle>
-                  <div className="flex items-center gap-1 text-xs">
-                    <Button
-                      variant={promptLanguage === "markdown" ? "secondary" : "ghost"}
-                      size="sm"
-                      className="h-6 px-2 text-xs"
-                      onClick={() => setPromptLanguage("markdown")}
-                    >
-                      Markdown
-                    </Button>
-                    <Button
-                      variant={promptLanguage === "toml" ? "secondary" : "ghost"}
-                      size="sm"
-                      className="h-6 px-2 text-xs"
-                      onClick={() => setPromptLanguage("toml")}
-                    >
-                      TOML
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-6 w-6 p-0"
-                      title="Pop out to window"
-                      onClick={() => {
-                        const popup = window.open("", "", "width=1000,height=700,left=200,top=100")
-                        if (!popup) return
-                        setPromptPopoutWindow(popup)
-                        setPromptModalOpen(false)
-                      }}
-                    >
-                      <ExternalLink className="h-3 w-3" />
-                    </Button>
-                    <DialogClose asChild>
-                      <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
-                        <X className="h-3 w-3" />
+            <DialogContent className="max-w-[90vw] w-[1000px] h-[80vh] p-0 overflow-hidden" showCloseButton={false}>
+              <div className="absolute inset-0 flex flex-col p-6 gap-4">
+                <DialogHeader>
+                  <div className="flex items-center justify-between">
+                    <DialogTitle>Edit System Prompt</DialogTitle>
+                    <div className="flex items-center gap-1 text-xs">
+                      <Button
+                        variant={promptLanguage === "markdown" ? "secondary" : "ghost"}
+                        size="sm"
+                        className="h-6 px-2 text-xs"
+                        onClick={() => setPromptLanguage("markdown")}
+                      >
+                        Markdown
                       </Button>
-                    </DialogClose>
+                      <Button
+                        variant={promptLanguage === "toml" ? "secondary" : "ghost"}
+                        size="sm"
+                        className="h-6 px-2 text-xs"
+                        onClick={() => setPromptLanguage("toml")}
+                      >
+                        TOML
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 w-6 p-0"
+                        title="Pop out to window"
+                        onClick={() => {
+                          const popup = window.open("", "", "width=1000,height=700,left=200,top=100")
+                          if (!popup) return
+                          setPromptPopoutWindow(popup)
+                          setPromptModalOpen(false)
+                        }}
+                      >
+                        <ExternalLink className="h-3 w-3" />
+                      </Button>
+                      <DialogClose asChild>
+                        <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
+                          <X className="h-3 w-3" />
+                        </Button>
+                      </DialogClose>
+                    </div>
                   </div>
+                </DialogHeader>
+                <div className="flex-1 min-h-0 flex flex-col">
+                  {workflow ? (
+                    <CodeMirrorExpressionEditor
+                      value={promptDraft}
+                      onChange={setPromptDraft}
+                      slug={slug}
+                      nodeId={node.node_id}
+                      workflow={workflow}
+                      language={promptLanguage}
+                      placeholder="Enter system prompt instructions..."
+                    />
+                  ) : (
+                    <Textarea
+                      className="flex-1 min-h-0 font-mono text-sm resize-none"
+                      value={promptDraft}
+                      onChange={(e) => setPromptDraft(e.target.value)}
+                      placeholder="Enter system prompt instructions..."
+                    />
+                  )}
                 </div>
-              </DialogHeader>
-              {workflow ? (
-                <CodeMirrorExpressionEditor
-                  value={promptDraft}
-                  onChange={setPromptDraft}
-                  slug={slug}
-                  nodeId={node.node_id}
-                  workflow={workflow}
-                  language={promptLanguage}
-                  placeholder="Enter system prompt instructions..."
-                />
-              ) : (
-                <Textarea
-                  className="flex-1 min-h-0 font-mono text-sm resize-none"
-                  value={promptDraft}
-                  onChange={(e) => setPromptDraft(e.target.value)}
-                  placeholder="Enter system prompt instructions..."
-                />
-              )}
-              <DialogFooter>
-                <Button variant="outline" onClick={() => setPromptModalOpen(false)}>Cancel</Button>
-                <Button onClick={() => { setSystemPrompt(promptDraft); saveOnNextRender.current = true; setPromptModalOpen(false) }}>Save</Button>
-              </DialogFooter>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setPromptModalOpen(false)}>Cancel</Button>
+                  <Button onClick={() => { setSystemPrompt(promptDraft); saveOnNextRender.current = true; setPromptModalOpen(false) }}>Save</Button>
+                </DialogFooter>
+              </div>
             </DialogContent>
           </Dialog>
 
@@ -1237,55 +1241,59 @@ function NodeConfigPanel({ slug, node, workflow, onClose }: Props) {
           </div>
 
           <Dialog open={codeModalOpen} onOpenChange={setCodeModalOpen}>
-            <DialogContent className="max-w-[90vw] w-[1000px] h-[80vh] flex flex-col" showCloseButton={false}>
-              <DialogHeader>
-                <div className="flex items-center justify-between">
-                  <DialogTitle>Edit Code — {codeLanguage}</DialogTitle>
-                  <div className="flex items-center gap-1">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-6 w-6 p-0"
-                      title="Pop out to window"
-                      onClick={() => {
-                        const popup = window.open("", "", "width=1000,height=700,left=200,top=100")
-                        if (!popup) return
-                        setCodePopoutWindow(popup)
-                        setCodeModalOpen(false)
-                      }}
-                    >
-                      <ExternalLink className="h-3 w-3" />
-                    </Button>
-                    <DialogClose asChild>
-                      <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
-                        <X className="h-3 w-3" />
+            <DialogContent className="max-w-[90vw] w-[1000px] h-[80vh] p-0 overflow-hidden" showCloseButton={false}>
+              <div className="absolute inset-0 flex flex-col p-6 gap-4">
+                <DialogHeader>
+                  <div className="flex items-center justify-between">
+                    <DialogTitle>Edit Code — {codeLanguage}</DialogTitle>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 w-6 p-0"
+                        title="Pop out to window"
+                        onClick={() => {
+                          const popup = window.open("", "", "width=1000,height=700,left=200,top=100")
+                          if (!popup) return
+                          setCodePopoutWindow(popup)
+                          setCodeModalOpen(false)
+                        }}
+                      >
+                        <ExternalLink className="h-3 w-3" />
                       </Button>
-                    </DialogClose>
+                      <DialogClose asChild>
+                        <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
+                          <X className="h-3 w-3" />
+                        </Button>
+                      </DialogClose>
+                    </div>
                   </div>
+                </DialogHeader>
+                <div className="flex-1 min-h-0 flex flex-col">
+                  {workflow ? (
+                    <CodeMirrorExpressionEditor
+                      value={codeDraft}
+                      onChange={setCodeDraft}
+                      slug={slug}
+                      nodeId={node.node_id}
+                      workflow={workflow}
+                      language={codeLanguage as CodeMirrorLanguage}
+                      placeholder="# Write your code here..."
+                    />
+                  ) : (
+                    <Textarea
+                      className="flex-1 min-h-0 font-mono text-sm resize-none"
+                      value={codeDraft}
+                      onChange={(e) => setCodeDraft(e.target.value)}
+                      placeholder="# Write your code here..."
+                    />
+                  )}
                 </div>
-              </DialogHeader>
-              {workflow ? (
-                <CodeMirrorExpressionEditor
-                  value={codeDraft}
-                  onChange={setCodeDraft}
-                  slug={slug}
-                  nodeId={node.node_id}
-                  workflow={workflow}
-                  language={codeLanguage as CodeMirrorLanguage}
-                  placeholder="# Write your code here..."
-                />
-              ) : (
-                <Textarea
-                  className="flex-1 min-h-0 font-mono text-sm resize-none"
-                  value={codeDraft}
-                  onChange={(e) => setCodeDraft(e.target.value)}
-                  placeholder="# Write your code here..."
-                />
-              )}
-              <DialogFooter>
-                <Button variant="outline" onClick={() => setCodeModalOpen(false)}>Cancel</Button>
-                <Button onClick={() => { setCodeSnippet(codeDraft); saveOnNextRender.current = true; setCodeModalOpen(false) }}>Save</Button>
-              </DialogFooter>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setCodeModalOpen(false)}>Cancel</Button>
+                  <Button onClick={() => { setCodeSnippet(codeDraft); saveOnNextRender.current = true; setCodeModalOpen(false) }}>Save</Button>
+                </DialogFooter>
+              </div>
             </DialogContent>
           </Dialog>
 
@@ -1743,55 +1751,59 @@ function NodeConfigPanel({ slug, node, workflow, onClose }: Props) {
           )}
 
           <Dialog open={extraConfigModalOpen} onOpenChange={setExtraConfigModalOpen}>
-            <DialogContent className="max-w-[90vw] w-[1000px] h-[80vh] flex flex-col" showCloseButton={false}>
-              <DialogHeader>
-                <div className="flex items-center justify-between">
-                  <DialogTitle>Edit Extra Config (JSON)</DialogTitle>
-                  <div className="flex items-center gap-1">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-6 w-6 p-0"
-                      title="Pop out to window"
-                      onClick={() => {
-                        const popup = window.open("", "", "width=1000,height=700,left=200,top=100")
-                        if (!popup) return
-                        setExtraConfigPopoutWindow(popup)
-                        setExtraConfigModalOpen(false)
-                      }}
-                    >
-                      <ExternalLink className="h-3 w-3" />
-                    </Button>
-                    <DialogClose asChild>
-                      <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
-                        <X className="h-3 w-3" />
+            <DialogContent className="max-w-[90vw] w-[1000px] h-[80vh] p-0 overflow-hidden" showCloseButton={false}>
+              <div className="absolute inset-0 flex flex-col p-6 gap-4">
+                <DialogHeader>
+                  <div className="flex items-center justify-between">
+                    <DialogTitle>Edit Extra Config (JSON)</DialogTitle>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 w-6 p-0"
+                        title="Pop out to window"
+                        onClick={() => {
+                          const popup = window.open("", "", "width=1000,height=700,left=200,top=100")
+                          if (!popup) return
+                          setExtraConfigPopoutWindow(popup)
+                          setExtraConfigModalOpen(false)
+                        }}
+                      >
+                        <ExternalLink className="h-3 w-3" />
                       </Button>
-                    </DialogClose>
+                      <DialogClose asChild>
+                        <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
+                          <X className="h-3 w-3" />
+                        </Button>
+                      </DialogClose>
+                    </div>
                   </div>
+                </DialogHeader>
+                <div className="flex-1 min-h-0 flex flex-col">
+                  {workflow ? (
+                    <CodeMirrorExpressionEditor
+                      value={extraConfigDraft}
+                      onChange={setExtraConfigDraft}
+                      slug={slug}
+                      nodeId={node.node_id}
+                      workflow={workflow}
+                      language="json"
+                      placeholder='{ "key": "value" }'
+                    />
+                  ) : (
+                    <Textarea
+                      className="flex-1 min-h-0 font-mono text-sm resize-none"
+                      value={extraConfigDraft}
+                      onChange={(e) => setExtraConfigDraft(e.target.value)}
+                      placeholder='{ "key": "value" }'
+                    />
+                  )}
                 </div>
-              </DialogHeader>
-              {workflow ? (
-                <CodeMirrorExpressionEditor
-                  value={extraConfigDraft}
-                  onChange={setExtraConfigDraft}
-                  slug={slug}
-                  nodeId={node.node_id}
-                  workflow={workflow}
-                  language="json"
-                  placeholder='{ "key": "value" }'
-                />
-              ) : (
-                <Textarea
-                  className="flex-1 min-h-0 font-mono text-sm resize-none"
-                  value={extraConfigDraft}
-                  onChange={(e) => setExtraConfigDraft(e.target.value)}
-                  placeholder='{ "key": "value" }'
-                />
-              )}
-              <DialogFooter>
-                <Button variant="outline" onClick={() => setExtraConfigModalOpen(false)}>Cancel</Button>
-                <Button onClick={() => { setExtraConfig(extraConfigDraft); saveOnNextRender.current = true; setExtraConfigModalOpen(false) }}>Save</Button>
-              </DialogFooter>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setExtraConfigModalOpen(false)}>Cancel</Button>
+                  <Button onClick={() => { setExtraConfig(extraConfigDraft); saveOnNextRender.current = true; setExtraConfigModalOpen(false) }}>Save</Button>
+                </DialogFooter>
+              </div>
             </DialogContent>
           </Dialog>
 

--- a/platform/frontend/src/index.css
+++ b/platform/frontend/src/index.css
@@ -150,36 +150,39 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
-    scrollbar-width: thin;
-    scrollbar-color: oklch(0.7 0 0 / 40%) transparent;
-  }
-  .dark * {
-    scrollbar-color: oklch(0.5 0 0 / 50%) transparent;
-  }
-  /* Webkit (Chrome, Edge, Safari) */
-  *::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
-  }
-  *::-webkit-scrollbar-track {
-    background: transparent;
-  }
-  *::-webkit-scrollbar-thumb {
-    background: oklch(0.7 0 0 / 40%);
-    border-radius: 3px;
-  }
-  *::-webkit-scrollbar-thumb:hover {
-    background: oklch(0.6 0 0 / 60%);
-  }
-  .dark *::-webkit-scrollbar-thumb {
-    background: oklch(0.5 0 0 / 50%);
-  }
-  .dark *::-webkit-scrollbar-thumb:hover {
-    background: oklch(0.6 0 0 / 70%);
   }
   body {
     @apply bg-background text-foreground;
   }
+}
+
+/* Thin themed scrollbars — outside @layer for full specificity */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: oklch(0.7 0 0 / 40%) transparent;
+}
+.dark * {
+  scrollbar-color: oklch(0.5 0 0 / 50%) transparent;
+}
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+*::-webkit-scrollbar-thumb {
+  background: oklch(0.7 0 0 / 40%);
+  border-radius: 3px;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: oklch(0.6 0 0 / 60%);
+}
+.dark *::-webkit-scrollbar-thumb {
+  background: oklch(0.5 0 0 / 50%);
+}
+.dark *::-webkit-scrollbar-thumb:hover {
+  background: oklch(0.6 0 0 / 70%);
 }
 
 /* Jinja2 template highlighting in CodeMirror — target self AND nested syntax spans */


### PR DESCRIPTION
## Summary
- Fix close (X) button overlapping with popout icon in System Prompt, Code, and Extra Config modals — now rendered inline side-by-side
- Fix CodeMirror editor height overflowing modal and popout window boundaries by adding `min-h-0` through the flex chain so editors scroll properly
- Add global thin themed scrollbars (6px, theme-aware light/dark colors) via CSS for both Firefox and Webkit browsers

## Test plan
- [ ] Open System Prompt / Code / Extra Config modal — verify X and popout icons sit side-by-side, no overlap
- [ ] Add enough content in any modal editor to exceed viewport — verify it scrolls within the modal
- [ ] Pop out an editor to a separate window — verify editor fills available space and scrolls
- [ ] Verify thin scrollbar styling in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)