### PR TITLE
Fix auto-tag workflow git identity

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Create and push tag
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "v${{ steps.version.outputs.version }}" \
             -m "Pipelit v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

- Configure `github-actions[bot]` git identity in the auto-tag workflow before creating annotated tags
- The runner has no default identity, which caused the v0.1.0 auto-tag to fail with `Committer identity unknown`
- Tag `v0.1.0` was created manually to unblock the release

## Test plan

- [ ] Verify next release PR merge triggers auto-tag successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)