### PR TITLE
Use flat-square style for shields.io badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 <p align="center">
   <a href="https://github.com/theuselessai/Pipelit/actions/workflows/ci.yml"><img src="https://github.com/theuselessai/Pipelit/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <a href="https://app.codecov.io/gh/theuselessai/Pipelit"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/theuselessai/pipelit"></a>
-  <a href="https://github.com/theuselessai/Pipelit/releases"><img src="https://img.shields.io/github/v/tag/theuselessai/Pipelit?label=version" alt="Version" /></a>
-  <a href="#license"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT" /></a>
+  <a href="https://app.codecov.io/gh/theuselessai/Pipelit"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/theuselessai/pipelit?style=flat-square"></a>
+  <a href="https://github.com/theuselessai/Pipelit/releases"><img src="https://img.shields.io/github/v/tag/theuselessai/Pipelit?label=version&style=flat-square" alt="Version" /></a>
+  <a href="#license"><img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License: MIT" /></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary
- Adds `style=flat-square` to Codecov, Version, and License shields.io badges for a consistent square look

## Test plan
- [ ] Verify badges render with flat-square style on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)