### PR TITLE
Dev plan: Sandbox mode, Alpine rootfs & platform config

### DIFF
--- a/docs/dev-plans/sandbox_plan.md
+++ b/docs/dev-plans/sandbox_plan.md
@@ -333,7 +333,7 @@ bwrap \
   --ro-bind /etc/resolv.conf /etc/resolv.conf \         # DNS (when network allowed)
   --clearenv \
   --setenv HOME /workspace \
-  --setenv PATH /usr/bin:/bin:/usr/local/bin:/workspace/.packages/bin \
+  --setenv PATH /usr/local/bin:/usr/bin:/bin:/workspace/.packages/bin \
   --setenv PIP_TARGET /workspace/.packages \
   --setenv PYTHONPATH /workspace/.packages \
   --setenv PYTHONDONTWRITEBYTECODE 1 \
@@ -483,7 +483,7 @@ args += ["--chdir", "/workspace"]
 args += ["--clearenv"]                   # wipe ALL inherited env vars
 args += [
     "--setenv", "HOME", "/workspace",
-    "--setenv", "PATH", "/usr/bin:/bin:/usr/local/bin:/workspace/.packages/bin",
+    "--setenv", "PATH", "/usr/local/bin:/usr/bin:/bin:/workspace/.packages/bin",
     "--setenv", "PIP_TARGET", "/workspace/.packages",
     "--setenv", "PYTHONPATH", "/workspace/.packages",
     "--setenv", "PYTHONDONTWRITEBYTECODE", "1",
@@ -506,7 +506,7 @@ In container mode, bwrap is not used but we still scrub the environment for subp
 def _build_sandbox_env(self, workspace_path: str) -> dict:
     """Build a clean environment for container-mode subprocess execution."""
     return {
-        "PATH": f"{workspace_path}/.packages/bin:/usr/local/bin:/usr/bin:/bin",
+        "PATH": f"/usr/local/bin:/usr/bin:/bin:{workspace_path}/.packages/bin",
         "HOME": workspace_path,
         "TMPDIR": "/tmp",
         "LANG": "C.UTF-8",


### PR DESCRIPTION
## Summary

Merges the two overlapping sandbox dev plans into a single comprehensive document:

- **sandbox_mode_config.md** (from PR #78) — broad plan covering security architecture, sandbox modes, setup wizard, conf.json, workspaces, code node sandboxing, settings page, frontend designs, testing
- **alpine_rootfs_sandbox.md** — focused plan for replacing host system binds with Alpine Linux mini rootfs

The merged document (`sandbox_plan.md`) covers the full scope: security architecture, Alpine rootfs provisioning, environment detection, setup wizard, configuration, workspace management, code node sandboxing, settings page, frontend designs, and testing.

### Key design decisions incorporated

| Topic | Decision |
|-------|----------|
| UID inside sandbox | Root (UID 0) inside user namespace — simpler, matches Docker conventions |
| Workspace mounting | Flat mount — entire host workspace dir at `/workspace` (rw) |
| `/tmp` handling | `workspace/.tmp` backs `/tmp` (persistent between commands, prevents agent file loss) |
| `/var/tmp` | Symlinked to `/tmp` in rootfs during setup |
| Document count | 2 overlapping docs → 1 merged doc |

### Files changed

- **Added:** `docs/dev-plans/sandbox_plan.md` (merged document)
- **Deleted:** `docs/dev-plans/alpine_rootfs_sandbox.md` (superseded)
- **Deleted:** `docs/dev-plans/sandbox_mode_config.md` (superseded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)