### PR TITLE
Add conf.json config layer and auto-generate secrets

### DIFF
--- a/platform/config.py
+++ b/platform/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
@@ -36,11 +37,17 @@ class PipelitConfig(BaseModel):
     detected_environment: dict = {}
 
 
+_logger = logging.getLogger(__name__)
+
+
 def load_conf() -> PipelitConfig:
     """Load conf.json from the pipelit data directory."""
     conf_path = get_pipelit_dir() / "conf.json"
     if conf_path.exists():
-        return PipelitConfig.model_validate_json(conf_path.read_text())
+        try:
+            return PipelitConfig.model_validate_json(conf_path.read_text())
+        except Exception:
+            _logger.warning("Failed to parse %s, using defaults", conf_path, exc_info=True)
     return PipelitConfig()
 
 
@@ -107,7 +114,7 @@ class Settings(BaseSettings):
     )
 
     ZOMBIE_EXECUTION_THRESHOLD_SECONDS: int = (
-        _conf.zombie_execution_threshold_seconds or 900
+        _conf.zombie_execution_threshold_seconds if _conf.zombie_execution_threshold_seconds is not None else 900
     )
 
     LOG_LEVEL: str = _conf.log_level or "INFO"


### PR DESCRIPTION
## Summary
- Introduces `PipelitConfig` model with `load_conf()`/`save_conf()` for a `conf.json` file (`~/.config/pipelit/conf.json`) that provides runtime config defaults below `.env` and env vars
- Auto-generates `FIELD_ENCRYPTION_KEY` (Fernet) and `SECRET_KEY` on first startup if missing, appending them to `.env`
- Adds `SANDBOX_MODE` and `PLATFORM_BASE_URL` settings fields
- Removes unused `ALLOWED_HOSTS` field
- 17 new tests covering conf.json loading, secret generation, Settings integration, and precedence (conf.json < .env < env vars)

## Test plan
- [x] All 17 new tests in `tests/test_config.py` pass
- [x] Full test suite passes (1756/1757, 1 pre-existing failure unrelated to this PR)
- [ ] Manual: start server without `FIELD_ENCRYPTION_KEY` in `.env` → verify key auto-generated
- [ ] Manual: create `conf.json` with `sandbox_mode: "bwrap"` → verify `settings.SANDBOX_MODE == "bwrap"`
- [ ] Manual: set `DATABASE_URL` in both `conf.json` and env var → verify env var wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)