### PR TITLE
Release v0.2.0 self-hosted beta

### DIFF
--- a/platform/frontend/src/api/workspaces.ts
+++ b/platform/frontend/src/api/workspaces.ts
@@ -12,7 +12,7 @@ export function useWorkspaces(params?: { limit?: number; offset?: number }) {
 
 export function useWorkspace(id: number | string) {
   return useQuery({
-    queryKey: ["workspace", id],
+    queryKey: ["workspace", String(id)],
     queryFn: () => apiFetch<Workspace>(`/workspaces/${id}/`),
     enabled: !!id,
   })
@@ -27,9 +27,9 @@ export function useUpdateWorkspace() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: ({ id, data }: { id: number; data: WorkspaceUpdate }) => apiFetch<Workspace>(`/workspaces/${id}/`, { method: "PATCH", body: JSON.stringify(data) }),
-    onSuccess: (_, vars) => {
+    onSuccess: (data, vars) => {
       qc.invalidateQueries({ queryKey: ["workspaces"] })
-      qc.invalidateQueries({ queryKey: ["workspace", vars.id] })
+      qc.setQueryData(["workspace", String(vars.id)], data)
     },
   })
 }
@@ -51,7 +51,7 @@ export function useResetWorkspace() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (id: number) => apiFetch<{ ok: boolean; message: string }>(`/workspaces/${id}/reset/`, { method: "POST" }),
-    onSuccess: (_, id) => qc.invalidateQueries({ queryKey: ["workspace", id] }),
+    onSuccess: (_, id) => qc.invalidateQueries({ queryKey: ["workspace", String(id)] }),
   })
 }
 
@@ -59,6 +59,6 @@ export function useResetWorkspaceRootfs() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: (id: number) => apiFetch<{ ok: boolean; message: string }>(`/workspaces/${id}/reset-rootfs/`, { method: "POST" }),
-    onSuccess: (_, id) => qc.invalidateQueries({ queryKey: ["workspace", id] }),
+    onSuccess: (_, id) => qc.invalidateQueries({ queryKey: ["workspace", String(id)] }),
   })
 }

--- a/platform/frontend/src/features/workflows/components/NodeDetailsPanel.tsx
+++ b/platform/frontend/src/features/workflows/components/NodeDetailsPanel.tsx
@@ -17,7 +17,7 @@ import { Separator } from "@/components/ui/separator"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogClose } from "@/components/ui/dialog"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Calendar } from "@/components/ui/calendar"
-import { X, Trash2, Send, Loader2, Expand, ExternalLink, RotateCcw, CalendarIcon, Plus, Play, Pause, Square, ChevronDown, ChevronUp } from "lucide-react"
+import { X, Trash2, Send, Loader2, Expand, ExternalLink, RotateCcw, CalendarIcon, Plus, Play, Pause, Square, ChevronDown, ChevronUp, Info } from "lucide-react"
 import { format } from "date-fns"
 import ExpressionTextarea from "@/components/ExpressionTextarea"
 import CodeMirrorExpressionEditor from "@/components/CodeMirrorExpressionEditor"
@@ -573,7 +573,7 @@ function NodeConfigPanel({ slug, node, workflow, onClose }: Props) {
   // Deep agent state
   const [workspaceId, setWorkspaceId] = useState<string>((node.config.extra_config?.workspace_id as number)?.toString() ?? "")
   const [enableTodos, setEnableTodos] = useState<boolean>(Boolean(node.config.extra_config?.enable_todos))
-  const [allowNetwork, setAllowNetwork] = useState<boolean>(Boolean(node.config.extra_config?.allow_network))
+  // Network access is controlled at the workspace level (not per-node)
   const [subagents, setSubagents] = useState<{ name: string; description: string; system_prompt: string; model: string }[]>(
     () => (node.config.extra_config?.subagents as { name: string; description: string; system_prompt: string; model: string }[]) ?? []
   )
@@ -722,7 +722,6 @@ function NodeConfigPanel({ slug, node, workflow, onClose }: Props) {
       parsedExtra = {
         ...parsedExtra,
         enable_todos: enableTodos,
-        allow_network: allowNetwork,
         subagents: subagents.filter((sa) => sa.name.trim() && sa.description.trim() && sa.system_prompt.trim()),
       }
     }
@@ -1378,21 +1377,14 @@ function NodeConfigPanel({ slug, node, workflow, onClose }: Props) {
               </div>
               <Switch checked={enableTodos} onCheckedChange={setEnableTodos} />
             </div>
-            <div className="flex items-center justify-between">
-              <div>
-                <Label className="text-xs">Network Access</Label>
-                <p className="text-xs text-muted-foreground">Allow outbound network (install packages, call APIs)</p>
-              </div>
-              <Switch checked={allowNetwork} onCheckedChange={setAllowNetwork} />
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Info className="h-3 w-3 shrink-0" />
+              <span>Network access is controlled by the workspace setting.</span>
             </div>
             <div className="space-y-1">
               <Label className="text-xs">Workspace</Label>
               <p className="text-xs text-muted-foreground">Sandboxed directory for file read/write operations</p>
-              <Select value={workspaceId} onValueChange={(v) => {
-                setWorkspaceId(v)
-                const ws = workspacesData?.items?.find((w) => w.id.toString() === v)
-                if (ws) setAllowNetwork(ws.allow_network)
-              }}>
+              <Select value={workspaceId} onValueChange={setWorkspaceId}>
                 <SelectTrigger className="text-xs h-7">
                   <SelectValue placeholder="Default workspace" />
                 </SelectTrigger>

--- a/platform/services/orchestrator.py
+++ b/platform/services/orchestrator.py
@@ -410,7 +410,8 @@ def execute_node_job(execution_id: str, node_id: str, retry_count: int = 0) -> N
 
         # Execution timeout enforcement
         if execution.started_at:
-            elapsed = (datetime.now(timezone.utc) - execution.started_at).total_seconds()
+            started = execution.started_at if execution.started_at.tzinfo else execution.started_at.replace(tzinfo=timezone.utc)
+            elapsed = (datetime.now(timezone.utc) - started).total_seconds()
             max_seconds = state.get("_max_execution_seconds")
             if max_seconds is None:
                 # Cache workflow timeout in state on first check


### PR DESCRIPTION
## Summary
- Remove redundant tool components and aggregator node
- Add human confirmation interrupt/resume flow
- Harden sandbox: block unsandboxed execution, lock platform_api base_url
- Add execution timeouts with max_execution_seconds
- Add health check endpoint and production hardening
- Fix workspace Network Access toggle cache bug
- Address multiple code review rounds (Redis leak, validations, logging)

## Test plan
- [ ] `npm run build` passes
- [ ] `python -m pytest tests/ -v` passes
- [ ] Manual smoke test of workflow execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)