### PR TITLE
feat: activity-based timeout watchdog for agent nodes

### DIFF
--- a/docs-site/docs/concepts/sandbox.md
+++ b/docs-site/docs/concepts/sandbox.md
@@ -186,6 +186,36 @@ Workspaces support injecting custom environment variables into the sandbox. Vari
 
 These variables are added to the bwrap `--setenv` list alongside the standard ones.
 
+## Debugging / Manual Access
+
+You can enter the sandbox interactively to inspect workspace state, test commands, or debug agent issues. From the workspace directory:
+
+```bash
+cd ~/.config/pipelit/workspaces/default  # or your workspace path
+
+bwrap --unshare-all --share-net \
+    --bind .rootfs/ / \
+    --bind . /workspace \
+    --bind .tmp /tmp \
+    --proc /proc \
+    --dev /dev \
+    --die-with-parent \
+    --clearenv \
+    --setenv HOME /workspace \
+    --setenv PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    --setenv TMPDIR /tmp \
+    --setenv LANG C.UTF-8 \
+    --setenv PIP_TARGET /workspace/.packages \
+    --setenv PYTHONPATH /workspace/.packages \
+    --chdir /workspace \
+    bash
+```
+
+This drops you into an interactive shell inside the sandbox with the same filesystem layout agents see.
+
+!!! tip "No-network testing"
+    Remove `--share-net` from the command to test with network access disabled — matching the default sandbox behavior. This is useful for verifying that an agent's commands work without network access.
+
 ## Security Considerations
 
 !!! note "bwrap vs. VM isolation"

--- a/platform/components/_agent_shared.py
+++ b/platform/components/_agent_shared.py
@@ -151,13 +151,17 @@ class PipelitAgentMiddleware(AgentMiddleware):
 
     state_schema = PipelitAgentState
 
-    def __init__(self, tool_metadata: dict[str, dict], agent_node_id: str, workflow_slug: str):
+    def __init__(self, tool_metadata: dict[str, dict], agent_node_id: str, workflow_slug: str, watchdog=None):
         super().__init__()
         self._tool_metadata = tool_metadata  # {tool_name: {tool_node_id, component_type}}
         self._agent_node_id = agent_node_id
         self._workflow_slug = workflow_slug
+        self._watchdog = watchdog
 
     def wrap_tool_call(self, request, handler):
+        if self._watchdog:
+            self._watchdog.ping()
+
         tool_name = request.tool_call.get("name", "") if isinstance(request.tool_call, dict) else getattr(request.tool_call, "name", "")
         meta = self._tool_metadata.get(tool_name, {})
         tool_node_id = meta.get("tool_node_id", "")
@@ -181,6 +185,8 @@ class PipelitAgentMiddleware(AgentMiddleware):
         )
         try:
             result = handler(request)
+            if self._watchdog:
+                self._watchdog.ping()
             _publish_tool_status(
                 tool_node_id=tool_node_id, status="success",
                 workflow_slug=self._workflow_slug,
@@ -190,6 +196,8 @@ class PipelitAgentMiddleware(AgentMiddleware):
             )
             return result
         except Exception as e:
+            if self._watchdog:
+                self._watchdog.ping()
             if isinstance(e, GraphInterrupt):
                 _publish_tool_status(
                     tool_node_id=tool_node_id, status="waiting",
@@ -209,10 +217,14 @@ class PipelitAgentMiddleware(AgentMiddleware):
             raise
 
     def wrap_model_call(self, request, handler):
+        if self._watchdog:
+            self._watchdog.ping()
         # Strip thinking blocks before the LLM call so they are never sent
         # to a different provider AND never persisted by the checkpointer.
         strip_thinking_blocks(request.messages)
         response = handler(request)
+        if self._watchdog:
+            self._watchdog.ping()
         try:
             exec_id = None
             state = request.state

--- a/platform/components/agent.py
+++ b/platform/components/agent.py
@@ -18,6 +18,7 @@ from components._agent_shared import (
     extract_text_content,
     strip_thinking_blocks,
 )
+from services.activity_watchdog import ActivityWatchdog, DEFAULT_INACTIVITY_TIMEOUT, DEFAULT_MAX_WALL_TIME
 from services.llm import resolve_llm_for_node
 from services.token_usage import (
     calculate_cost,
@@ -74,6 +75,11 @@ def agent_factory(node):
     tools, tool_metadata = _resolve_tools(node)
     skill_paths = _resolve_skills(node)
 
+    # Activity watchdog — extends RQ timeout while agent is active
+    inactivity_timeout = int(extra.get("inactivity_timeout", DEFAULT_INACTIVITY_TIMEOUT))
+    max_wall_time = int(extra.get("max_wall_time", DEFAULT_MAX_WALL_TIME))
+    watchdog = ActivityWatchdog(inactivity_timeout=inactivity_timeout, max_wall_time=max_wall_time)
+
     # Detect spawn_and_await tool
     has_spawn_tool = any(
         getattr(t, "name", "") == "spawn_and_await" for t in tools
@@ -89,7 +95,7 @@ def agent_factory(node):
     elif has_spawn_tool:
         checkpointer = _get_redis_checkpointer()
 
-    middleware = PipelitAgentMiddleware(tool_metadata, node_id, workflow_slug)
+    middleware = PipelitAgentMiddleware(tool_metadata, node_id, workflow_slug, watchdog=watchdog)
 
     # Build middleware list — optionally prepend SummarizationMiddleware
     middlewares: list = []
@@ -144,6 +150,16 @@ def agent_factory(node):
     )
 
     def agent_node(state: dict) -> dict:
+        from datetime import datetime, timezone
+        from langgraph.types import Command
+
+        watchdog.start()
+        try:
+            return _agent_node_inner(state)
+        finally:
+            watchdog.stop()
+
+    def _agent_node_inner(state: dict) -> dict:
         from datetime import datetime, timezone
         from langgraph.types import Command
 

--- a/platform/components/deep_agent.py
+++ b/platform/components/deep_agent.py
@@ -21,6 +21,7 @@ from components._agent_shared import (
     extract_text_content,
     strip_thinking_blocks,
 )
+from services.activity_watchdog import ActivityWatchdog, DEFAULT_INACTIVITY_TIMEOUT, DEFAULT_MAX_WALL_TIME
 from services.llm import resolve_llm_for_node
 from services.token_usage import (
     calculate_cost,
@@ -112,6 +113,11 @@ def deep_agent_factory(node):
     tools, tool_metadata = _resolve_tools(node)
     skill_paths = _resolve_skills(node)
 
+    # Activity watchdog — extends RQ timeout while agent is active
+    inactivity_timeout = int(extra.get("inactivity_timeout", DEFAULT_INACTIVITY_TIMEOUT))
+    max_wall_time = int(extra.get("max_wall_time", DEFAULT_MAX_WALL_TIME))
+    watchdog = ActivityWatchdog(inactivity_timeout=inactivity_timeout, max_wall_time=max_wall_time)
+
     # Checkpointer selection (same logic as regular agent)
     checkpointer = None
     if conversation_memory:
@@ -121,7 +127,7 @@ def deep_agent_factory(node):
         checkpointer = _get_redis_checkpointer()
 
     # Build middleware
-    middleware = PipelitAgentMiddleware(tool_metadata, node_id, workflow_slug)
+    middleware = PipelitAgentMiddleware(tool_metadata, node_id, workflow_slug, watchdog=watchdog)
 
     # Build memory list for create_deep_agent
     memory_features: list[str] = ["filesystem"]  # always enabled (sandboxed)
@@ -169,6 +175,15 @@ def deep_agent_factory(node):
     )
 
     def deep_agent_node(state: dict) -> dict:
+        from datetime import datetime, timezone
+
+        watchdog.start()
+        try:
+            return _deep_agent_node_inner(state)
+        finally:
+            watchdog.stop()
+
+    def _deep_agent_node_inner(state: dict) -> dict:
         from datetime import datetime, timezone
 
         messages = list(state.get("messages", []))

--- a/platform/services/activity_watchdog.py
+++ b/platform/services/activity_watchdog.py
@@ -1,0 +1,108 @@
+"""Activity-based timeout watchdog for agent nodes.
+
+RQ's SimpleWorker uses signal.alarm(timeout) → SIGALRM to kill jobs.
+Calling signal.alarm(N) from within the job resets the countdown.
+
+This watchdog extends the timeout while the agent is actively working
+(LLM calls, tool calls) and enforces a hard ceiling (max_wall_time)
+to prevent runaway agents.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import time
+
+logger = logging.getLogger(__name__)
+
+# Defaults
+DEFAULT_INACTIVITY_TIMEOUT = 600  # 10 minutes — local bwrap tests can take >5min
+DEFAULT_MAX_WALL_TIME = 7200  # 2 hours — ceiling for complex multi-step agents
+
+
+class ActivityWatchdog:
+    """Resets RQ's SIGALRM timer on each activity ping.
+
+    Usage::
+
+        watchdog = ActivityWatchdog(inactivity_timeout=600, max_wall_time=7200)
+        watchdog.start()
+        try:
+            # ... agent work ...
+            watchdog.ping()  # called by middleware on each LLM/tool call
+        finally:
+            watchdog.stop()
+    """
+
+    def __init__(
+        self,
+        inactivity_timeout: int = DEFAULT_INACTIVITY_TIMEOUT,
+        max_wall_time: int = DEFAULT_MAX_WALL_TIME,
+    ):
+        self._inactivity_timeout = inactivity_timeout
+        self._max_wall_time = max_wall_time
+        self._start_time: float | None = None
+        self._active = False
+        self._can_alarm = _can_use_alarm()
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    def start(self) -> None:
+        """Record start time and set the initial SIGALRM."""
+        self._start_time = time.monotonic()
+        self._active = True
+        self._set_alarm(self._inactivity_timeout)
+        logger.info(
+            "ActivityWatchdog started: inactivity=%ds, max_wall=%ds",
+            self._inactivity_timeout,
+            self._max_wall_time,
+        )
+
+    def ping(self) -> None:
+        """Reset the SIGALRM countdown if still within max_wall_time."""
+        if not self._active or self._start_time is None:
+            return
+
+        elapsed = time.monotonic() - self._start_time
+        remaining = self._max_wall_time - elapsed
+
+        if remaining <= 0:
+            # Past the ceiling — let the current alarm fire naturally
+            logger.warning(
+                "ActivityWatchdog: max_wall_time exceeded (%.0fs elapsed), "
+                "not extending timeout",
+                elapsed,
+            )
+            return
+
+        timeout = min(self._inactivity_timeout, remaining)
+        self._set_alarm(int(timeout))
+
+    def stop(self) -> None:
+        """Deactivate the watchdog. Does NOT cancel any pending alarm
+        (RQ manages that)."""
+        self._active = False
+        self._start_time = None
+
+    def _set_alarm(self, seconds: int) -> None:
+        """Set SIGALRM, with graceful fallback if unavailable."""
+        if not self._can_alarm:
+            return
+        try:
+            signal.alarm(max(1, seconds))
+        except (OSError, ValueError):
+            logger.debug("ActivityWatchdog: signal.alarm() failed", exc_info=True)
+
+
+def _can_use_alarm() -> bool:
+    """Check if signal.alarm is available (main thread on Unix)."""
+    if not hasattr(signal, "alarm"):
+        return False
+    try:
+        import threading
+        return threading.current_thread() is threading.main_thread()
+    except Exception:
+        return False

--- a/platform/services/orchestrator.py
+++ b/platform/services/orchestrator.py
@@ -31,7 +31,7 @@ def _redis() -> redis_lib.Redis:
 
 def _queue() -> Queue:
     conn = redis_lib.from_url(settings.REDIS_URL)
-    return Queue("workflows", connection=conn, default_timeout=600)
+    return Queue("workflows", connection=conn, default_timeout=7200)
 
 
 # ── Redis state helpers ────────────────────────────────────────────────────────

--- a/platform/tests/test_activity_watchdog.py
+++ b/platform/tests/test_activity_watchdog.py
@@ -1,0 +1,221 @@
+"""Tests for the activity-based timeout watchdog."""
+
+from __future__ import annotations
+
+import signal
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.activity_watchdog import ActivityWatchdog, DEFAULT_INACTIVITY_TIMEOUT, DEFAULT_MAX_WALL_TIME
+
+
+class TestActivityWatchdogBasics:
+    """Core watchdog behavior."""
+
+    def test_defaults(self):
+        wd = ActivityWatchdog()
+        assert wd._inactivity_timeout == DEFAULT_INACTIVITY_TIMEOUT
+        assert wd._max_wall_time == DEFAULT_MAX_WALL_TIME
+        assert not wd.active
+
+    def test_custom_values(self):
+        wd = ActivityWatchdog(inactivity_timeout=120, max_wall_time=3600)
+        assert wd._inactivity_timeout == 120
+        assert wd._max_wall_time == 3600
+
+    def test_start_activates(self):
+        wd = ActivityWatchdog()
+        with patch("services.activity_watchdog._can_use_alarm", return_value=False):
+            wd._can_alarm = False
+            wd.start()
+            assert wd.active
+            assert wd._start_time is not None
+
+    def test_stop_deactivates(self):
+        wd = ActivityWatchdog()
+        wd._can_alarm = False
+        wd.start()
+        wd.stop()
+        assert not wd.active
+        assert wd._start_time is None
+
+    def test_ping_noop_before_start(self):
+        """Ping before start() should be a no-op."""
+        wd = ActivityWatchdog()
+        wd._can_alarm = False
+        wd.ping()  # should not raise
+
+    def test_ping_noop_after_stop(self):
+        """Ping after stop() should be a no-op."""
+        wd = ActivityWatchdog()
+        wd._can_alarm = False
+        wd.start()
+        wd.stop()
+        wd.ping()  # should not raise
+
+
+class TestAlarmReset:
+    """Test that ping resets the alarm via signal.alarm."""
+
+    def test_start_sets_alarm(self):
+        wd = ActivityWatchdog(inactivity_timeout=300, max_wall_time=7200)
+        wd._can_alarm = True
+        with patch.object(signal, "alarm") as mock_alarm:
+            wd.start()
+            mock_alarm.assert_called_once_with(300)
+
+    def test_ping_resets_alarm(self):
+        wd = ActivityWatchdog(inactivity_timeout=300, max_wall_time=7200)
+        wd._can_alarm = True
+        wd._start_time = time.monotonic()
+        wd._active = True
+        with patch.object(signal, "alarm") as mock_alarm:
+            wd.ping()
+            mock_alarm.assert_called_once_with(300)
+
+    def test_ping_uses_remaining_when_less_than_inactivity(self):
+        """When remaining wall time < inactivity_timeout, use remaining."""
+        wd = ActivityWatchdog(inactivity_timeout=600, max_wall_time=100)
+        wd._can_alarm = True
+        wd._active = True
+        # Simulate 50s elapsed of 100s max
+        wd._start_time = time.monotonic() - 50
+        with patch.object(signal, "alarm") as mock_alarm:
+            wd.ping()
+            # remaining = 100 - 50 = 50, which is < 600
+            args = mock_alarm.call_args[0]
+            assert args[0] <= 51  # allow 1s tolerance
+
+
+class TestMaxWallTime:
+    """Test max_wall_time ceiling stops extension."""
+
+    def test_ping_does_not_extend_past_max_wall_time(self):
+        """After max_wall_time, ping should NOT call signal.alarm."""
+        wd = ActivityWatchdog(inactivity_timeout=300, max_wall_time=60)
+        wd._can_alarm = True
+        wd._active = True
+        # Simulate 70s elapsed (past 60s ceiling)
+        wd._start_time = time.monotonic() - 70
+        with patch.object(signal, "alarm") as mock_alarm:
+            wd.ping()
+            mock_alarm.assert_not_called()
+
+
+class TestGracefulFallback:
+    """Test fallback when signal.alarm is unavailable."""
+
+    def test_no_alarm_attribute(self):
+        """When signal.alarm doesn't exist, watchdog still works (no-op)."""
+        wd = ActivityWatchdog()
+        wd._can_alarm = False
+        wd.start()
+        wd.ping()
+        wd.stop()
+        # No exceptions raised
+
+    def test_alarm_oserror_handled(self):
+        """When signal.alarm raises OSError, it's handled gracefully."""
+        wd = ActivityWatchdog(inactivity_timeout=300)
+        wd._can_alarm = True
+        wd._active = True
+        wd._start_time = time.monotonic()
+        with patch.object(signal, "alarm", side_effect=OSError("not supported")):
+            wd.ping()  # should not raise
+
+
+class TestMiddlewareIntegration:
+    """Test that middleware pings the watchdog on tool/model calls."""
+
+    def test_wrap_tool_call_pings_watchdog(self):
+        from components._agent_shared import PipelitAgentMiddleware
+
+        mock_watchdog = MagicMock()
+        mw = PipelitAgentMiddleware(
+            tool_metadata={},
+            agent_node_id="agent_1",
+            workflow_slug="test-wf",
+            watchdog=mock_watchdog,
+        )
+
+        mock_request = MagicMock()
+        mock_request.tool_call = {"name": "test_tool"}
+        mock_request.state = {}
+        mock_handler = MagicMock(return_value="result")
+
+        with patch("components._agent_shared._publish_tool_status"):
+            result = mw.wrap_tool_call(mock_request, mock_handler)
+
+        assert result == "result"
+        # Should ping on entry and after handler returns
+        assert mock_watchdog.ping.call_count == 2
+
+    def test_wrap_tool_call_pings_on_exception(self):
+        from components._agent_shared import PipelitAgentMiddleware
+
+        mock_watchdog = MagicMock()
+        mw = PipelitAgentMiddleware(
+            tool_metadata={},
+            agent_node_id="agent_1",
+            workflow_slug="test-wf",
+            watchdog=mock_watchdog,
+        )
+
+        mock_request = MagicMock()
+        mock_request.tool_call = {"name": "test_tool"}
+        mock_request.state = {}
+        mock_handler = MagicMock(side_effect=RuntimeError("tool failed"))
+
+        with patch("components._agent_shared._publish_tool_status"):
+            with pytest.raises(RuntimeError, match="tool failed"):
+                mw.wrap_tool_call(mock_request, mock_handler)
+
+        # Should ping on entry and after exception
+        assert mock_watchdog.ping.call_count == 2
+
+    def test_wrap_model_call_pings_watchdog(self):
+        from components._agent_shared import PipelitAgentMiddleware
+
+        mock_watchdog = MagicMock()
+        mw = PipelitAgentMiddleware(
+            tool_metadata={},
+            agent_node_id="agent_1",
+            workflow_slug="test-wf",
+            watchdog=mock_watchdog,
+        )
+
+        mock_request = MagicMock()
+        mock_request.messages = []
+        mock_request.state = {}
+        mock_response = MagicMock()
+        mock_response.result = []
+        mock_handler = MagicMock(return_value=mock_response)
+
+        result = mw.wrap_model_call(mock_request, mock_handler)
+
+        assert result == mock_response
+        # Should ping on entry and after handler returns
+        assert mock_watchdog.ping.call_count == 2
+
+    def test_no_watchdog_no_pings(self):
+        """When watchdog is None, no errors and no pings."""
+        from components._agent_shared import PipelitAgentMiddleware
+
+        mw = PipelitAgentMiddleware(
+            tool_metadata={},
+            agent_node_id="agent_1",
+            workflow_slug="test-wf",
+            watchdog=None,
+        )
+
+        mock_request = MagicMock()
+        mock_request.messages = []
+        mock_request.state = {}
+        mock_response = MagicMock()
+        mock_response.result = []
+        mock_handler = MagicMock(return_value=mock_response)
+
+        result = mw.wrap_model_call(mock_request, mock_handler)
+        assert result == mock_response


### PR DESCRIPTION
## Summary

- **Activity watchdog**: Agent nodes now reset their RQ SIGALRM timer on each LLM call and tool call, so active agents are no longer killed after 600s. A hard ceiling of 7200s (2 hours) prevents runaway agents.
- **RQ timeout raised**: `default_timeout` bumped from 600s → 7200s to match the watchdog ceiling.
- **Sandbox docs**: Added "Debugging / Manual Access" section with the `bwrap` command for entering the sandbox interactively.

## How it works

RQ's `SimpleWorker` uses `signal.alarm(timeout)` → SIGALRM to kill jobs. The `ActivityWatchdog` calls `signal.alarm(inactivity_timeout)` on each activity ping from the agent middleware, resetting the countdown. After `max_wall_time` total elapsed, it stops extending.

| Parameter | Default | Rationale |
|-----------|---------|-----------|
| `inactivity_timeout` | 600s (10 min) | Local bwrap tests can take >5min |
| `max_wall_time` | 7200s (2 hrs) | Ceiling for complex multi-step agents |
| RQ `default_timeout` | 7200s | Raised to match ceiling |

Both values are configurable per-node via `extra_config.inactivity_timeout` and `extra_config.max_wall_time`.

## Files changed

- `platform/services/activity_watchdog.py` — new `ActivityWatchdog` class
- `platform/components/_agent_shared.py` — middleware pings watchdog on tool/model calls
- `platform/components/agent.py` — watchdog start/stop lifecycle
- `platform/components/deep_agent.py` — same pattern as agent.py
- `platform/services/orchestrator.py` — `default_timeout` 600 → 7200
- `platform/tests/test_activity_watchdog.py` — 16 new tests
- `docs-site/docs/concepts/sandbox.md` — debugging/manual access section

## Test plan

- [x] 16/16 new watchdog tests pass (`pytest tests/test_activity_watchdog.py`)
- [x] 20/20 existing zombie execution tests pass (`pytest tests/test_zombie_execution_fixes.py`)
- [x] 1918/1921 full suite pass (3 failures pre-existing on master)
- [x] docs-site builds cleanly (`mkdocs build`)
- [ ] Manual: trigger a long-running agent via Telegram, confirm it survives past 600s

🤖 Generated with [Claude Code](https://claude.com/claude-code)