### PR TITLE
feat: Telegram document upload support

### DIFF
--- a/platform/handlers/telegram.py
+++ b/platform/handlers/telegram.py
@@ -23,7 +23,23 @@ class TelegramTriggerHandler:
         user_id = message.get("from", {}).get("id")
         chat_id = message.get("chat", {}).get("id")
         message_id = message.get("message_id")
-        text = message.get("text", "")
+        text = message.get("text", "") or message.get("caption", "")
+
+        files = []
+        doc = message.get("document")
+        if doc:
+            file_name = doc.get("file_name", "document")
+            file_id = doc.get("file_id", "")
+            mime = doc.get("mime_type", "")
+            file_tag = f"[Attached file: {file_name} | file_id: {file_id} | type: {mime}]"
+            files.append({
+                "file_id": file_id,
+                "file_unique_id": doc.get("file_unique_id"),
+                "file_name": file_name,
+                "mime_type": mime,
+                "file_size": doc.get("file_size", 0),
+            })
+            text = f"{text}\n{file_tag}".strip() if text else file_tag
 
         if not user_id or not chat_id:
             return
@@ -38,6 +54,7 @@ class TelegramTriggerHandler:
             "chat_id": chat_id,
             "message_id": message_id,
             "text": text,
+            "files": files,
             "bot_token": bot_token,
         }
 

--- a/platform/schemas/node_type_defs.py
+++ b/platform/schemas/node_type_defs.py
@@ -12,6 +12,7 @@ register_node_type(NodeTypeSpec(
     outputs=[
         PortDefinition(name="text", data_type=DataType.STRING, description="Message text"),
         PortDefinition(name="chat_id", data_type=DataType.NUMBER, description="Telegram chat ID"),
+        PortDefinition(name="files", data_type=DataType.ARRAY, description="Document files (file_id, file_name, mime_type, file_size)"),
         PortDefinition(name="payload", data_type=DataType.OBJECT, description="Full trigger payload"),
     ],
 ))

--- a/platform/tests/test_telegram_handler.py
+++ b/platform/tests/test_telegram_handler.py
@@ -10,21 +10,26 @@ from models.execution import PendingTask, WorkflowExecution
 from models.user import UserProfile
 
 
-def _make_update(user_id=111222333, chat_id=999, message_id=1, text="hello"):
+def _make_update(user_id=111222333, chat_id=999, message_id=1, text="hello",
+                  document=None, caption=None):
     """Build a minimal Telegram update dict."""
-    return {
-        "message": {
-            "message_id": message_id,
-            "from": {
-                "id": user_id,
-                "first_name": "Test",
-                "last_name": "User",
-                "username": "testuser",
-            },
-            "chat": {"id": chat_id},
-            "text": text,
-        }
+    msg = {
+        "message_id": message_id,
+        "from": {
+            "id": user_id,
+            "first_name": "Test",
+            "last_name": "User",
+            "username": "testuser",
+        },
+        "chat": {"id": chat_id},
     }
+    if text is not None:
+        msg["text"] = text
+    if caption is not None:
+        msg["caption"] = caption
+    if document is not None:
+        msg["document"] = document
+    return {"message": msg}
 
 
 class TestHandleMessage:
@@ -80,6 +85,88 @@ class TestHandleMessage:
             handler.handle_message("123456:ABC-DEF", update, db)
 
         assert db.query(UserProfile).filter(UserProfile.telegram_user_id == 777888999).first() is not None
+
+    def test_document_message_includes_files(self, db, user_profile, telegram_trigger):
+        """A document message should populate the files array in event_data."""
+        handler = TelegramTriggerHandler()
+        update = _make_update(
+            text=None,
+            caption="my notes",
+            document={
+                "file_id": "BQACAgIAAxk",
+                "file_unique_id": "AgADBQAC",
+                "file_name": "notes.txt",
+                "mime_type": "text/plain",
+                "file_size": 1234,
+            },
+        )
+
+        with (
+            patch("handlers.redis"),
+            patch("handlers.Queue") as mock_queue_cls,
+            patch("handlers.telegram.output_delivery"),
+        ):
+            mock_queue_cls.return_value.enqueue.return_value = None
+            handler.handle_message("123456:ABC-DEF", update, db)
+
+        exec_row = db.query(WorkflowExecution).first()
+        assert exec_row is not None
+        payload = exec_row.trigger_payload
+        assert payload["text"].startswith("my notes\n")
+        assert "file_id: BQACAgIAAxk" in payload["text"]
+        assert "notes.txt" in payload["text"]
+        assert len(payload["files"]) == 1
+        assert payload["files"][0]["file_id"] == "BQACAgIAAxk"
+        assert payload["files"][0]["file_name"] == "notes.txt"
+        assert payload["files"][0]["mime_type"] == "text/plain"
+        assert payload["files"][0]["file_size"] == 1234
+
+    def test_document_without_caption_generates_text(self, db, user_profile, telegram_trigger):
+        """A document without caption should generate text with file_id."""
+        handler = TelegramTriggerHandler()
+        update = _make_update(
+            text=None,
+            document={
+                "file_id": "BQACAgIAAxk",
+                "file_unique_id": "AgADBQAC",
+                "file_name": "report.pdf",
+                "mime_type": "application/pdf",
+                "file_size": 5678,
+            },
+        )
+
+        with (
+            patch("handlers.redis"),
+            patch("handlers.Queue") as mock_queue_cls,
+            patch("handlers.telegram.output_delivery"),
+        ):
+            mock_queue_cls.return_value.enqueue.return_value = None
+            handler.handle_message("123456:ABC-DEF", update, db)
+
+        exec_row = db.query(WorkflowExecution).first()
+        assert exec_row is not None
+        text = exec_row.trigger_payload["text"]
+        assert "report.pdf" in text
+        assert "file_id: BQACAgIAAxk" in text
+        assert "application/pdf" in text
+        assert len(exec_row.trigger_payload["files"]) == 1
+
+    def test_text_message_has_empty_files(self, db, user_profile, telegram_trigger):
+        """A plain text message should have an empty files array."""
+        handler = TelegramTriggerHandler()
+        update = _make_update(text="just text")
+
+        with (
+            patch("handlers.redis"),
+            patch("handlers.Queue") as mock_queue_cls,
+            patch("handlers.telegram.output_delivery"),
+        ):
+            mock_queue_cls.return_value.enqueue.return_value = None
+            handler.handle_message("123456:ABC-DEF", update, db)
+
+        exec_row = db.query(WorkflowExecution).first()
+        assert exec_row is not None
+        assert exec_row.trigger_payload["files"] == []
 
 
 class TestHandleConfirmation:


### PR DESCRIPTION
## Summary
- Handle Telegram document messages by extracting file metadata (`file_id`, `file_name`, `mime_type`, `file_size`) into a `files` array on the trigger payload
- Include `file_id` in the message text so agents can download files via the Telegram `getFile` API without hallucinating IDs
- Generate descriptive fallback text for documents without captions, preventing the assistant-prefill error when conversation memory is enabled
- Add `files` output port to `trigger_telegram` node type definition

## Test plan
- [x] `test_document_message_includes_files` — document with caption populates files array and includes file_id in text
- [x] `test_document_without_caption_generates_text` — document without caption generates text with file_id and mime type
- [x] `test_text_message_has_empty_files` — plain text messages have empty files array
- [x] All 13 telegram handler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)