### PR TITLE
feat: mount skill directories into bwrap sandbox

### DIFF
--- a/platform/components/_agent_shared.py
+++ b/platform/components/_agent_shared.py
@@ -184,13 +184,16 @@ def _resolve_credential_field(cred, field: str) -> str | None:
     return None
 
 
-def _build_backend(extra: dict):
+def _build_backend(extra: dict, skill_paths: list[str] | None = None):
     """Build a sandboxed shell backend.
 
     Returns a ``SandboxedShellBackend`` that wraps ``execute()`` in OS-level
     sandboxing (bwrap on Linux, sandbox-exec on macOS) so shell commands are
     confined to the workspace directory.  Filesystem tools are also sandboxed
     via ``virtual_mode=True``.
+
+    When *skill_paths* is given, the host directories are mounted read-only
+    at ``/.skill_providers/<basename>/`` inside the bwrap sandbox.
     """
     from components.sandboxed_backend import SandboxedShellBackend
 
@@ -231,10 +234,17 @@ def _build_backend(extra: dict):
 
     root_dir = os.path.expanduser(root_dir)
     os.makedirs(root_dir, exist_ok=True)
+
+    extra_ro_binds: list[tuple[str, str]] | None = None
+    if skill_paths:
+        _, sandbox_to_host = _compute_skill_path_mapping(skill_paths)
+        extra_ro_binds = [(host, sandbox) for sandbox, host in sandbox_to_host.items()]
+
     return SandboxedShellBackend(
         root_dir=root_dir,
         allow_network=allow_network,
         custom_env=env_vars if env_vars else None,
+        extra_ro_binds=extra_ro_binds,
     )
 
 
@@ -531,7 +541,7 @@ def _resolve_skills(node) -> list[str]:
                         from pathlib import Path
                         from config import settings
                         skill_path = settings.SKILLS_DIR if settings.SKILLS_DIR else str(
-                            Path.home() / ".config" / "pipelit" / "skills"
+                            Path.home() / ".config" / "pipelit" / "community_skills"
                         )
 
                     try:
@@ -573,6 +583,35 @@ def _resolve_skills(node) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Skill path mapping — host paths → sandbox mount paths
+# ---------------------------------------------------------------------------
+
+
+def _compute_skill_path_mapping(host_paths: list[str]) -> tuple[list[str], dict[str, str]]:
+    """Map host skill directories to sandbox mount paths under ``/.skill_providers/``.
+
+    Returns:
+        (sandbox_paths, sandbox_to_host) where sandbox_to_host maps
+        ``/.skill_providers/<name>`` → ``/host/path``.
+    """
+    sandbox_paths: list[str] = []
+    sandbox_to_host: dict[str, str] = {}
+    seen: dict[str, int] = {}
+    for host_path in host_paths:
+        basename = os.path.basename(host_path.rstrip("/")) or "default"
+        if basename in seen:
+            seen[basename] += 1
+            name = f"{basename}_{seen[basename]}"
+        else:
+            seen[basename] = 0
+            name = basename
+        sp = f"/.skill_providers/{name}"
+        sandbox_paths.append(sp)
+        sandbox_to_host[sp] = host_path.rstrip("/")
+    return sandbox_paths, sandbox_to_host
+
+
+# ---------------------------------------------------------------------------
 # SkillAwareBackend — routes skill-path file reads to the real filesystem
 # ---------------------------------------------------------------------------
 
@@ -583,13 +622,18 @@ class SkillAwareBackend:
     Everything else is delegated to the *default* backend (typically
     ``StateBackend``).  This allows ``SkillsMiddleware`` to load SKILL.md
     files from disk even when the agent's primary backend is in-memory.
+
+    When *sandbox_to_host* is provided, sandbox paths like
+    ``/.skill_providers/X/file`` are translated to their host equivalents
+    before reading from the real filesystem.
     """
 
-    def __init__(self, default, skill_paths: list[str]):
+    def __init__(self, default, skill_paths: list[str], sandbox_to_host: dict[str, str] | None = None):
         from deepagents.backends.filesystem import FilesystemBackend
 
         self._default = default
         self._skill_paths = [p.rstrip("/") for p in skill_paths]
+        self._sandbox_to_host = sandbox_to_host or {}
         # FilesystemBackend with root_dir=None: absolute paths used as-is
         self._fs = FilesystemBackend(root_dir=None, virtual_mode=False)
 
@@ -600,26 +644,39 @@ class SkillAwareBackend:
             for sp in self._skill_paths
         )
 
+    def _translate_to_host_path(self, path: str) -> str:
+        """Translate a sandbox skill path to its host filesystem equivalent.
+
+        E.g. ``/.skill_providers/claude_skills/web/SKILL.md``
+        → ``/home/user/.config/pipelit/claude_skills/web/SKILL.md``
+        """
+        for sandbox_prefix, host_prefix in self._sandbox_to_host.items():
+            sp = sandbox_prefix.rstrip("/")
+            p = path.rstrip("/") if path == sp else path
+            if p == sp or p.startswith(sp + "/"):
+                return host_prefix + p[len(sp):]
+        return path
+
     # -- Routed methods (skill paths → filesystem, others → default) --------
 
     def ls_info(self, path):
         if self._is_skill_path(path):
-            return self._fs.ls_info(path)
+            return self._fs.ls_info(self._translate_to_host_path(path))
         return self._default.ls_info(path)
 
     async def als_info(self, path):
         if self._is_skill_path(path):
-            return await self._fs.als_info(path)
+            return await self._fs.als_info(self._translate_to_host_path(path))
         return await self._default.als_info(path)
 
     def read(self, file_path, offset=0, limit=2000):
         if self._is_skill_path(file_path):
-            return self._fs.read(file_path, offset, limit)
+            return self._fs.read(self._translate_to_host_path(file_path), offset, limit)
         return self._default.read(file_path, offset, limit)
 
     async def aread(self, file_path, offset=0, limit=2000):
         if self._is_skill_path(file_path):
-            return await self._fs.aread(file_path, offset, limit)
+            return await self._fs.aread(self._translate_to_host_path(file_path), offset, limit)
         return await self._default.aread(file_path, offset, limit)
 
     def download_files(self, paths):
@@ -628,7 +685,7 @@ class SkillAwareBackend:
         for i, path in enumerate(paths):
             if self._is_skill_path(path):
                 skill_indices.append(i)
-                skill_paths_list.append(path)
+                skill_paths_list.append(self._translate_to_host_path(path))
             else:
                 default_indices.append(i)
                 default_paths_list.append(path)
@@ -648,7 +705,7 @@ class SkillAwareBackend:
         for i, path in enumerate(paths):
             if self._is_skill_path(path):
                 skill_indices.append(i)
-                skill_paths_list.append(path)
+                skill_paths_list.append(self._translate_to_host_path(path))
             else:
                 default_indices.append(i)
                 default_paths_list.append(path)
@@ -711,7 +768,11 @@ except ImportError:
     SandboxBackendProtocol = None  # type: ignore[assignment,misc]
 
 
-def _make_skill_aware_backend(default_backend_or_factory, skill_paths: list[str]):
+def _make_skill_aware_backend(
+    default_backend_or_factory,
+    skill_paths: list[str],
+    sandbox_to_host: dict[str, str] | None = None,
+):
     """Create a backend factory that wraps the default backend with skill-aware routing.
 
     The returned factory is compatible with ``create_deep_agent(backend=...)`` and
@@ -721,6 +782,9 @@ def _make_skill_aware_backend(default_backend_or_factory, skill_paths: list[str]
     When the resolved default backend is a ``SandboxBackendProtocol`` (i.e.
     supports ``execute()``), returns a ``SandboxedSkillAwareBackend`` so that
     the execute tool remains available.
+
+    When *sandbox_to_host* is provided, ``SkillAwareBackend`` translates
+    sandbox paths (``/.skill_providers/X/...``) to host paths before reading.
     """
 
     def factory(tool_runtime):
@@ -735,8 +799,8 @@ def _make_skill_aware_backend(default_backend_or_factory, skill_paths: list[str]
             default = default_backend_or_factory
 
         if SandboxBackendProtocol is not None and isinstance(default, SandboxBackendProtocol):
-            return SandboxedSkillAwareBackend(default, skill_paths)
-        return SkillAwareBackend(default, skill_paths)
+            return SandboxedSkillAwareBackend(default, skill_paths, sandbox_to_host=sandbox_to_host)
+        return SkillAwareBackend(default, skill_paths, sandbox_to_host=sandbox_to_host)
 
     return factory
 

--- a/platform/components/deep_agent.py
+++ b/platform/components/deep_agent.py
@@ -12,6 +12,7 @@ from components import register
 from components._agent_shared import (
     PipelitAgentMiddleware,
     _build_backend,
+    _compute_skill_path_mapping,
     _get_ai_model_extra,
     _get_checkpointer,
     _get_redis_checkpointer,
@@ -160,7 +161,7 @@ def deep_agent_factory(node):
         memory_features.append("todos")
 
     # Build backend — always sandboxed to workspace directory
-    backend = _build_backend(extra)
+    backend = _build_backend(extra, skill_paths=skill_paths if skill_paths else None)
 
     # Build subagents
     subagents = _build_subagents(extra)
@@ -181,11 +182,28 @@ def deep_agent_factory(node):
     if subagents:
         agent_kwargs["subagents"] = subagents
     if skill_paths:
+        # Compute sandbox path mapping for bwrap mounts
+        sandbox_skill_paths, sandbox_to_host = _compute_skill_path_mapping(skill_paths)
+
+        # Check if bwrap is active — if so, use sandbox paths; otherwise use host paths
+        use_sandbox_paths = getattr(backend, "_resolution", None) and backend._resolution.mode == "bwrap"
+        effective_skill_paths = sandbox_skill_paths if use_sandbox_paths else skill_paths
+        effective_sandbox_to_host = sandbox_to_host if use_sandbox_paths else None
+
         # Wrap the sandboxed backend so SkillsMiddleware reads skill files
         # from real filesystem while agent writes stay sandboxed.
-        agent_kwargs["backend"] = _make_skill_aware_backend(backend, skill_paths)
-        agent_kwargs["skills"] = skill_paths
-        logger.info("DeepAgent %s: passing %d skill sources with SkillAwareBackend", node_id, len(skill_paths))
+        agent_kwargs["backend"] = _make_skill_aware_backend(
+            backend, effective_skill_paths, sandbox_to_host=effective_sandbox_to_host,
+        )
+        agent_kwargs["skills"] = effective_skill_paths
+        logger.info("DeepAgent %s: passing %d skill sources with SkillAwareBackend (bwrap=%s)", node_id, len(skill_paths), use_sandbox_paths)
+
+        # Inject skill provider paths into system prompt so agent knows about them
+        if use_sandbox_paths and sandbox_skill_paths:
+            provider_list = ", ".join(f"`{p}/`" for p in sandbox_skill_paths)
+            skill_context = f"\nSkill providers (read-only): {provider_list}"
+            system_prompt = f"{system_prompt}{skill_context}" if system_prompt else skill_context.lstrip()
+            agent_kwargs["system_prompt"] = system_prompt
 
     agent = create_deep_agent(**agent_kwargs)
 

--- a/platform/components/sandboxed_backend.py
+++ b/platform/components/sandboxed_backend.py
@@ -58,7 +58,7 @@ def _build_bwrap_command(
     workspace: str,
     workspace_rootfs: str,
     *,
-    extra_ro_binds: list[str] | None = None,
+    extra_ro_binds: list[tuple[str, str]] | None = None,
     allow_network: bool = False,
 ) -> list[str]:
     """Build a bwrap command line for Linux sandboxing with Alpine rootfs.
@@ -92,11 +92,13 @@ def _build_bwrap_command(
             args += ["--ro-bind", "/etc/resolv.conf", "/etc/resolv.conf"]
         args += ["--share-net"]
 
-    # Extra read-only binds (e.g. skill directories)
+    # Extra read-only binds (e.g. skill directories) — (host_path, sandbox_path)
     if extra_ro_binds:
-        for path in extra_ro_binds:
-            if os.path.exists(path):
-                args += ["--ro-bind", path, path]
+        for host_path, sandbox_path in extra_ro_binds:
+            if os.path.exists(host_path):
+                rootfs_mount_point = os.path.join(workspace_rootfs, sandbox_path.lstrip("/"))
+                os.makedirs(rootfs_mount_point, exist_ok=True)
+                args += ["--ro-bind", host_path, sandbox_path]
 
     args += ["--die-with-parent"]
 
@@ -134,9 +136,9 @@ class SandboxedShellBackend(LocalShellBackend):
         Workspace directory — the only writable location inside the sandbox.
     allow_network : bool
         Whether to allow network access inside the sandbox (default False).
-    extra_ro_binds : list[str] | None
-        Additional paths to mount read-only inside the sandbox (e.g. skill
-        directories).
+    extra_ro_binds : list[tuple[str, str]] | None
+        Additional (host_path, sandbox_path) pairs to mount read-only inside
+        the sandbox (e.g. skill directories at ``/.skill_providers/``).
     timeout : int
         Default timeout in seconds for shell commands.
     max_output_bytes : int
@@ -148,7 +150,7 @@ class SandboxedShellBackend(LocalShellBackend):
         root_dir: str | Path,
         *,
         allow_network: bool = False,
-        extra_ro_binds: list[str] | None = None,
+        extra_ro_binds: list[tuple[str, str]] | None = None,
         custom_env: dict[str, str] | None = None,
         timeout: int = _DEFAULT_TIMEOUT,
         max_output_bytes: int = 100_000,

--- a/platform/config.py
+++ b/platform/config.py
@@ -125,7 +125,7 @@ class Settings(BaseSettings):
     SANDBOX_MODE: str = _conf.sandbox_mode or "auto"
     PLATFORM_BASE_URL: str = _conf.platform_base_url or "http://localhost:8000"
 
-    SKILLS_DIR: str = ""  # default: ~/.config/pipelit/skills/ (resolved at runtime)
+    SKILLS_DIR: str = ""  # default: ~/.config/pipelit/community_skills/ (resolved at runtime)
     WORKSPACE_DIR: str = ""  # default: ~/.config/pipelit/workspaces/default (resolved at runtime)
     ROOTFS_DIR: str = ""  # default: {pipelit_dir}/rootfs/ (resolved at runtime)
 

--- a/platform/main.py
+++ b/platform/main.py
@@ -93,7 +93,7 @@ async def lifespan(app: FastAPI):
 
     # Ensure skills directory exists
     try:
-        skills_dir = Path(settings.SKILLS_DIR) if settings.SKILLS_DIR else Path.home() / ".config" / "pipelit" / "skills"
+        skills_dir = Path(settings.SKILLS_DIR) if settings.SKILLS_DIR else Path.home() / ".config" / "pipelit" / "community_skills"
         skills_dir.mkdir(parents=True, exist_ok=True)
         logger.info("Skills directory: %s", skills_dir)
     except Exception:

--- a/platform/services/capabilities.py
+++ b/platform/services/capabilities.py
@@ -123,6 +123,12 @@ def format_capability_context(caps: dict) -> str:
     if fs_status:
         lines.append(f"Filesystem: {', '.join(fs_status)}")
 
+    # Skill providers (injected by caller, not auto-detected)
+    skill_providers = fs.get("skill_providers", [])
+    if skill_providers:
+        provider_list = ", ".join(f"`{p}`" for p in skill_providers)
+        lines.append(f"Skill providers (read-only): {provider_list}")
+
     return "\n".join(lines)
 
 

--- a/platform/tests/test_capabilities.py
+++ b/platform/tests/test_capabilities.py
@@ -205,3 +205,45 @@ class TestCheckWritable:
         from services.capabilities import _check_writable
         with patch("tempfile.mkstemp", side_effect=OSError("permission denied")):
             assert _check_writable("/nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# Skill provider detection
+# ---------------------------------------------------------------------------
+
+
+class TestSkillProviders:
+    def test_format_skill_providers(self):
+        """format_capability_context includes skill provider paths when passed."""
+        caps = {
+            "runtimes": {},
+            "shell_tools": {},
+            "network": {"dns": False, "http": False},
+            "filesystem": {
+                "workspace_writable": True,
+                "tmp_writable": True,
+                "skill_providers": ["/.skill_providers/skills/", "/.skill_providers/skills_1/"],
+            },
+        }
+
+        from services.capabilities import format_capability_context
+        output = format_capability_context(caps)
+
+        assert "/.skill_providers/skills/" in output
+        assert "/.skill_providers/skills_1/" in output
+        assert "read-only" in output.lower()
+
+    def test_format_no_skill_providers(self):
+        """format_capability_context omits skill line when no providers."""
+        caps = {
+            "runtimes": {},
+            "shell_tools": {},
+            "network": {"dns": False, "http": False},
+            "filesystem": {"skill_providers": []},
+        }
+
+        from services.capabilities import format_capability_context
+        output = format_capability_context(caps)
+
+        assert "skill_providers" not in output.lower()
+        assert "/.skill_providers" not in output

--- a/platform/tests/test_sandboxed_backend.py
+++ b/platform/tests/test_sandboxed_backend.py
@@ -205,6 +205,69 @@ class TestBwrapCommand:
         cmd = _build_bwrap_command("echo hi", workspace, rootfs, allow_network=False)
         assert "--share-net" not in cmd
 
+    def test_extra_ro_binds_tuple_format(self, tmp_path):
+        """extra_ro_binds accepts (host_path, sandbox_path) tuples."""
+        from components.sandboxed_backend import _build_bwrap_command
+
+        workspace = str(tmp_path / "ws")
+        rootfs = str(tmp_path / "rootfs")
+        os.makedirs(workspace, exist_ok=True)
+
+        skill_dir = str(tmp_path / "skills")
+        os.makedirs(skill_dir, exist_ok=True)
+
+        cmd = _build_bwrap_command(
+            "echo hi", workspace, rootfs,
+            extra_ro_binds=[(skill_dir, "/.skill_providers/skills")],
+        )
+
+        ro_bind_pairs = []
+        for i, v in enumerate(cmd):
+            if v == "--ro-bind" and i + 2 < len(cmd):
+                ro_bind_pairs.append((cmd[i + 1], cmd[i + 2]))
+
+        assert (skill_dir, "/.skill_providers/skills") in ro_bind_pairs
+
+    def test_extra_ro_binds_creates_rootfs_mount_point(self, tmp_path):
+        """extra_ro_binds creates the mount point directory in the rootfs."""
+        from components.sandboxed_backend import _build_bwrap_command
+
+        workspace = str(tmp_path / "ws")
+        rootfs = str(tmp_path / "rootfs")
+        os.makedirs(workspace, exist_ok=True)
+        os.makedirs(rootfs, exist_ok=True)
+
+        skill_dir = str(tmp_path / "skills")
+        os.makedirs(skill_dir, exist_ok=True)
+
+        _build_bwrap_command(
+            "echo hi", workspace, rootfs,
+            extra_ro_binds=[(skill_dir, "/.skill_providers/web")],
+        )
+
+        mount_point = os.path.join(rootfs, ".skill_providers", "web")
+        assert os.path.isdir(mount_point)
+
+    def test_extra_ro_binds_skips_nonexistent_host_path(self, tmp_path):
+        """extra_ro_binds skips entries where host path doesn't exist."""
+        from components.sandboxed_backend import _build_bwrap_command
+
+        workspace = str(tmp_path / "ws")
+        rootfs = str(tmp_path / "rootfs")
+        os.makedirs(workspace, exist_ok=True)
+
+        cmd = _build_bwrap_command(
+            "echo hi", workspace, rootfs,
+            extra_ro_binds=[("/nonexistent/path", "/.skill_providers/nope")],
+        )
+
+        ro_bind_pairs = []
+        for i, v in enumerate(cmd):
+            if v == "--ro-bind" and i + 2 < len(cmd):
+                ro_bind_pairs.append((cmd[i + 1], cmd[i + 2]))
+
+        assert ("/nonexistent/path", "/.skill_providers/nope") not in ro_bind_pairs
+
     def test_no_host_system_binds(self, tmp_path):
         """No /usr, /bin, /lib, /sbin, /etc ro-binds from host system."""
         from components.sandboxed_backend import _build_bwrap_command

--- a/platform/tests/test_skill_node.py
+++ b/platform/tests/test_skill_node.py
@@ -303,7 +303,8 @@ def test_resolve_skills_empty_path_uses_default(db, workflow):
         result = _resolve_skills(agent_node)
         assert len(result) == 1
         # Should end with the platform default path
-        assert result[0].endswith(".config/pipelit/skills")
+        # May end with community_skills or community_skills/skills (auto-detected subdir)
+        assert ".config/pipelit/community_skills" in result[0]
 
 
 # ── Workflow validation tests ─────────────────────────────────────────────────
@@ -899,9 +900,157 @@ class TestDeepAgentFactorySkills:
             deep_agent_factory(mock_node)
 
             # _make_skill_aware_backend should have been called with the backend and paths
-            mock_make_skill.assert_called_once_with(mock_backend, ["/skills/code"])
+            mock_make_skill.assert_called_once()
+            call_args = mock_make_skill.call_args
+            assert call_args[0][0] is mock_backend
+            # When no bwrap, host paths are used directly
+            assert call_args[0][1] == ["/skills/code"]
 
             # create_deep_agent should receive the skill-aware factory as backend and skill_paths
             create_call_kwargs = mock_create.call_args[1]
             assert create_call_kwargs["backend"] is mock_skill_factory
             assert create_call_kwargs["skills"] == ["/skills/code"]
+
+    def test_deep_agent_factory_with_skills_bwrap_mode(self):
+        """deep_agent_factory uses sandbox paths when bwrap mode is active."""
+        mock_node = MagicMock()
+        mock_node.node_id = "deep_agent_002"
+        mock_node.workflow_id = 1
+        mock_node.workflow.slug = "test-wf"
+        mock_node.component_config.concrete.system_prompt = "You are helpful."
+        mock_node.component_config.concrete.extra_config = {}
+        mock_node.component_config.concrete.max_tokens = None
+
+        mock_backend = MagicMock()
+        mock_backend._resolution = MagicMock()
+        mock_backend._resolution.mode = "bwrap"
+        mock_skill_factory = MagicMock()
+
+        with patch("components.deep_agent._resolve_skills", return_value=["/home/user/skills/web", "/home/user/skills/code"]), \
+             patch("components.deep_agent.resolve_llm_for_node", return_value=MagicMock()), \
+             patch("components.deep_agent._resolve_tools", return_value=([], {})), \
+             patch("components.deep_agent.get_model_name_for_node", return_value="test-model"), \
+             patch("components.deep_agent._build_backend", return_value=mock_backend), \
+             patch("components.deep_agent._make_skill_aware_backend", return_value=mock_skill_factory) as mock_make_skill, \
+             patch("components.deep_agent._get_redis_checkpointer", return_value=MagicMock()), \
+             patch("components.deep_agent.create_deep_agent") as mock_create:
+            mock_create.return_value = MagicMock(invoke=MagicMock(return_value={"messages": []}))
+            from components.deep_agent import deep_agent_factory
+            deep_agent_factory(mock_node)
+
+            # _make_skill_aware_backend should use sandbox paths in bwrap mode
+            mock_make_skill.assert_called_once()
+            call_args = mock_make_skill.call_args
+            assert call_args[0][1] == ["/.skill_providers/web", "/.skill_providers/code"]
+            assert call_args[1]["sandbox_to_host"] == {
+                "/.skill_providers/web": "/home/user/skills/web",
+                "/.skill_providers/code": "/home/user/skills/code",
+            }
+
+            # create_deep_agent should receive sandbox paths as skills
+            create_call_kwargs = mock_create.call_args[1]
+            assert create_call_kwargs["skills"] == ["/.skill_providers/web", "/.skill_providers/code"]
+
+
+# ── _compute_skill_path_mapping tests ───────────────────────────────────────
+
+
+class TestComputeSkillPathMapping:
+    """Tests for _compute_skill_path_mapping() helper."""
+
+    def test_single_path(self):
+        from components._agent_shared import _compute_skill_path_mapping
+        sandbox_paths, mapping = _compute_skill_path_mapping(["/home/user/skills"])
+        assert sandbox_paths == ["/.skill_providers/skills"]
+        assert mapping == {"/.skill_providers/skills": "/home/user/skills"}
+
+    def test_multiple_paths(self):
+        from components._agent_shared import _compute_skill_path_mapping
+        sandbox_paths, mapping = _compute_skill_path_mapping(["/skills/web", "/skills/code"])
+        assert sandbox_paths == ["/.skill_providers/web", "/.skill_providers/code"]
+        assert mapping == {
+            "/.skill_providers/web": "/skills/web",
+            "/.skill_providers/code": "/skills/code",
+        }
+
+    def test_collision_handling(self):
+        from components._agent_shared import _compute_skill_path_mapping
+        sandbox_paths, mapping = _compute_skill_path_mapping([
+            "/a/skills", "/b/skills", "/c/skills",
+        ])
+        assert sandbox_paths == [
+            "/.skill_providers/skills",
+            "/.skill_providers/skills_1",
+            "/.skill_providers/skills_2",
+        ]
+        assert mapping["/.skill_providers/skills"] == "/a/skills"
+        assert mapping["/.skill_providers/skills_1"] == "/b/skills"
+        assert mapping["/.skill_providers/skills_2"] == "/c/skills"
+
+    def test_trailing_slash_stripped(self):
+        from components._agent_shared import _compute_skill_path_mapping
+        sandbox_paths, mapping = _compute_skill_path_mapping(["/home/user/skills/"])
+        assert sandbox_paths == ["/.skill_providers/skills"]
+        assert mapping["/.skill_providers/skills"] == "/home/user/skills"
+
+    def test_empty_basename_uses_default(self):
+        from components._agent_shared import _compute_skill_path_mapping
+        sandbox_paths, mapping = _compute_skill_path_mapping(["/"])
+        assert sandbox_paths == ["/.skill_providers/default"]
+        assert mapping["/.skill_providers/default"] == ""
+
+
+# ── SkillAwareBackend path translation tests ────────────────────────────────
+
+
+class TestSkillAwareBackendTranslation:
+    """Tests for SkillAwareBackend._translate_to_host_path()."""
+
+    def _make_backend(self, skill_paths, sandbox_to_host):
+        from components._agent_shared import SkillAwareBackend
+        default = MagicMock()
+        return SkillAwareBackend(default, skill_paths, sandbox_to_host=sandbox_to_host), default
+
+    def test_translate_exact_match(self):
+        backend, _ = self._make_backend(
+            ["/.skill_providers/web"],
+            {"/.skill_providers/web": "/home/user/skills/web"},
+        )
+        assert backend._translate_to_host_path("/.skill_providers/web") == "/home/user/skills/web"
+
+    def test_translate_child_path(self):
+        backend, _ = self._make_backend(
+            ["/.skill_providers/web"],
+            {"/.skill_providers/web": "/home/user/skills/web"},
+        )
+        assert backend._translate_to_host_path("/.skill_providers/web/SKILL.md") == "/home/user/skills/web/SKILL.md"
+
+    def test_translate_no_mapping_passthrough(self):
+        backend, _ = self._make_backend(
+            ["/.skill_providers/web"],
+            {"/.skill_providers/web": "/home/user/skills/web"},
+        )
+        assert backend._translate_to_host_path("/workspace/file.py") == "/workspace/file.py"
+
+    def test_translate_empty_mapping(self):
+        backend, _ = self._make_backend(["/skills"], None)
+        assert backend._translate_to_host_path("/skills/web/SKILL.md") == "/skills/web/SKILL.md"
+
+    def test_read_translates_sandbox_path(self):
+        backend, default = self._make_backend(
+            ["/.skill_providers/web"],
+            {"/.skill_providers/web": "/home/user/skills/web"},
+        )
+        with patch.object(backend._fs, "read", return_value="# SKILL.md") as fs_read:
+            result = backend.read("/.skill_providers/web/SKILL.md")
+            fs_read.assert_called_once_with("/home/user/skills/web/SKILL.md", 0, 2000)
+            assert result == "# SKILL.md"
+
+    def test_ls_info_translates_sandbox_path(self):
+        backend, default = self._make_backend(
+            ["/.skill_providers/code"],
+            {"/.skill_providers/code": "/opt/skills/code"},
+        )
+        with patch.object(backend._fs, "ls_info", return_value=[]) as fs_ls:
+            backend.ls_info("/.skill_providers/code")
+            fs_ls.assert_called_once_with("/opt/skills/code")


### PR DESCRIPTION
## Summary

- Mount skill node directories read-only at `/.skill_providers/<basename>/` inside the bwrap sandbox so agents can access skill scripts via `execute()`
- `SkillAwareBackend` translates sandbox paths back to host paths for file reads
- Inject skill provider paths into the system prompt so agents know about the mount points
- Update default skills fallback from `~/.config/pipelit/skills/` to `~/.config/pipelit/community_skills/`

## Test plan

- [x] Existing tests pass (128 total across skill + sandbox tests)
- [x] New tests for `_compute_skill_path_mapping()` (single, multiple, collision, trailing slash)
- [x] New tests for `_build_bwrap_command()` with tuple binds (format, rootfs mount point, nonexistent skip)
- [x] New tests for `SkillAwareBackend._translate_to_host_path()` (exact, child, passthrough, integration)
- [x] New test for deep_agent_factory bwrap mode wiring
- [x] New tests for capability context skill provider formatting
- [ ] Manual test: connect skill nodes to deep agent, verify `ls /.skill_providers/` works inside sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)