### PR TITLE
fix: use Redis SETNX lock to prevent duplicate telegram polls

### DIFF
--- a/platform/services/telegram_poller.py
+++ b/platform/services/telegram_poller.py
@@ -29,6 +29,7 @@ def poll_telegram_credential(credential_id: int, error_count: int = 0) -> None:
     Called by RQ worker on the ``telegram`` queue.
     """
     db = SessionLocal()
+    _next_error_count = None  # None = don't reschedule (credential gone / no active nodes)
     try:
         # Load credential
         base_cred = db.get(BaseCredential, credential_id)
@@ -72,12 +73,12 @@ def poll_telegram_credential(credential_id: int, error_count: int = 0) -> None:
             data = resp.json()
         except Exception:
             logger.exception("Telegram getUpdates failed for credential %s", credential_id)
-            _enqueue_poll(credential_id, error_count + 1)
+            _next_error_count = error_count + 1
             return
 
         if not data.get("ok"):
             logger.error("Telegram API error for credential %s: %s", credential_id, data.get("description"))
-            _enqueue_poll(credential_id, error_count + 1)
+            _next_error_count = error_count + 1
             return
 
         updates = data.get("result", [])
@@ -95,13 +96,18 @@ def poll_telegram_credential(credential_id: int, error_count: int = 0) -> None:
             r.set(offset_key, str(new_offset), ex=OFFSET_TTL)
 
         # Self-reschedule immediately on success
-        _enqueue_poll(credential_id, 0)
+        _next_error_count = 0
 
     except Exception:
         logger.exception("Fatal error in poll_telegram_credential(%s)", credential_id)
-        _enqueue_poll(credential_id, error_count + 1)
+        _next_error_count = error_count + 1
     finally:
         db.close()
+        # Release lock THEN re-enqueue (order matters!)
+        conn = redis.from_url(settings.REDIS_URL)
+        conn.delete(f"tg-poll-active:{credential_id}")
+        if _next_error_count is not None:
+            _enqueue_poll(credential_id, _next_error_count)
 
 
 def _route_update(bot_token: str, update: dict, db) -> None:
@@ -144,27 +150,37 @@ def _backoff(error_count: int) -> int:
 
 
 def _enqueue_poll(credential_id: int, error_count: int) -> None:
-    """Enqueue the next poll cycle with deterministic job ID.
+    """Enqueue the next poll cycle with Redis SETNX deduplication.
 
-    Cleans up any finished/failed job with the same ID first to prevent
-    stale jobs from blocking re-enqueue.
+    Uses an atomic SET NX lock to ensure only one poll job per credential
+    is active at a time.  TTL of 120s covers 30s long-poll + 60s job_timeout
+    + 30s margin — if the worker crashes, the lock auto-expires.
     """
     from rq.job import Job
     from tasks import poll_telegram_credential_task
 
     conn = redis.from_url(settings.REDIS_URL)
-    q = Queue("telegram", connection=conn)
+    lock_key = f"tg-poll-active:{credential_id}"
     rq_job_id = f"tg-poll-{credential_id}"
 
-    # Clean up stale job with same ID (finished/failed/canceled)
+    # Atomic dedup: only one poll per credential at a time
+    if not conn.set(lock_key, "1", nx=True, ex=120):
+        logger.debug("Poll already active for credential %s, skipping enqueue", credential_id)
+        return
+
+    # Clean up old job with same ID if it's in a terminal state.
+    # The job may still be "started" when called from the finally block
+    # of the current run (RQ hasn't marked it finished yet), so we must
+    # NOT delete it in that case — just let RQ overwrite it on enqueue.
     try:
         old = Job.fetch(rq_job_id, connection=conn)
         status = old.get_status()
         if status in ("finished", "failed", "canceled", "stopped"):
             old.delete()
-    except Exception as e:
-        logger.debug("No existing job %s to clean up: %s", rq_job_id, e)
+    except Exception:
+        pass
 
+    q = Queue("telegram", connection=conn)
     delay = _backoff(error_count)
     if delay > 0:
         q.enqueue_in(

--- a/platform/tests/test_telegram_poller.py
+++ b/platform/tests/test_telegram_poller.py
@@ -289,6 +289,36 @@ class TestPollTelegramCredential:
 
         mock_enqueue.assert_called_once_with(telegram_credential.id, 0)
 
+    def test_poll_releases_lock_before_reschedule(self, db, telegram_credential, telegram_trigger):
+        """Lock should be released in finally block before calling _enqueue_poll."""
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = None
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"ok": True, "result": []}
+        mock_resp.raise_for_status.return_value = None
+
+        call_order = []
+
+        def track_delete(*args):
+            call_order.append("delete")
+
+        def track_enqueue(*args):
+            call_order.append("enqueue")
+
+        mock_redis.delete.side_effect = track_delete
+
+        with (
+            patch("services.telegram_poller.SessionLocal", return_value=db),
+            patch("services.telegram_poller.redis.from_url", return_value=mock_redis),
+            patch("services.telegram_poller.requests.post", return_value=mock_resp),
+            patch("services.telegram_poller._enqueue_poll", side_effect=track_enqueue),
+        ):
+            poll_telegram_credential(telegram_credential.id)
+
+        mock_redis.delete.assert_called_once_with(f"tg-poll-active:{telegram_credential.id}")
+        assert call_order == ["delete", "enqueue"]
+
 
 # ---------------------------------------------------------------------------
 # Recovery Tests
@@ -537,7 +567,7 @@ class TestTelegramPollAPI:
 # ---------------------------------------------------------------------------
 
 class TestEnqueuePoll:
-    """Tests for _enqueue_poll stale job cleanup and backoff logic."""
+    """Tests for _enqueue_poll SETNX lock and backoff logic."""
 
     def test_enqueue_poll_cleans_finished_job(self):
         """Finished job with same ID should be deleted before re-enqueue."""
@@ -545,8 +575,8 @@ class TestEnqueuePoll:
 
         mock_old_job = MagicMock()
         mock_old_job.get_status.return_value = "finished"
-
         mock_conn = MagicMock()
+        mock_conn.set.return_value = True  # SETNX succeeds
         mock_queue = MagicMock()
 
         with (
@@ -559,14 +589,14 @@ class TestEnqueuePoll:
         mock_old_job.delete.assert_called_once()
         mock_queue.enqueue.assert_called_once()
 
-    def test_enqueue_poll_skips_started_job(self):
-        """Started job should NOT be deleted."""
+    def test_enqueue_poll_skips_delete_for_started_job(self):
+        """Started job should NOT be deleted (still running), but enqueue should proceed."""
         from services.telegram_poller import _enqueue_poll
 
         mock_old_job = MagicMock()
         mock_old_job.get_status.return_value = "started"
-
         mock_conn = MagicMock()
+        mock_conn.set.return_value = True  # SETNX succeeds
         mock_queue = MagicMock()
 
         with (
@@ -579,11 +609,31 @@ class TestEnqueuePoll:
         mock_old_job.delete.assert_not_called()
         mock_queue.enqueue.assert_called_once()
 
+    def test_enqueue_poll_skips_when_lock_held(self):
+        """SETNX returning False should skip enqueue entirely."""
+        from services.telegram_poller import _enqueue_poll
+
+        mock_conn = MagicMock()
+        mock_conn.set.return_value = False  # SETNX fails — lock held
+        mock_queue = MagicMock()
+
+        with (
+            patch("services.telegram_poller.redis.from_url", return_value=mock_conn),
+            patch("services.telegram_poller.Queue", return_value=mock_queue),
+            patch("rq.job.Job.fetch") as mock_fetch,
+        ):
+            _enqueue_poll(42, 0)
+
+        mock_fetch.assert_not_called()
+        mock_queue.enqueue.assert_not_called()
+        mock_queue.enqueue_in.assert_not_called()
+
     def test_enqueue_poll_handles_missing_job(self):
         """Job.fetch raising exception should not prevent enqueue."""
         from services.telegram_poller import _enqueue_poll
 
         mock_conn = MagicMock()
+        mock_conn.set.return_value = True  # SETNX succeeds
         mock_queue = MagicMock()
 
         with (
@@ -600,6 +650,7 @@ class TestEnqueuePoll:
         from services.telegram_poller import _enqueue_poll
 
         mock_conn = MagicMock()
+        mock_conn.set.return_value = True  # SETNX succeeds
         mock_queue = MagicMock()
 
         with (
@@ -621,6 +672,7 @@ class TestEnqueuePoll:
         from services.telegram_poller import _enqueue_poll
 
         mock_conn = MagicMock()
+        mock_conn.set.return_value = True  # SETNX succeeds
         mock_queue = MagicMock()
 
         with (


### PR DESCRIPTION
## Summary
- Replace RQ Job.fetch status checks with Redis SETNX lock for telegram poll deduplication
- Move reschedule logic to `finally` block: release lock then re-enqueue
- Only delete old jobs in terminal states (not "started") to avoid corrupting running jobs

The previous approach failed because `_enqueue_poll` is called from within the running job's `finally` block, where the job status is still "started". This caused the self-reschedule to either be blocked (status check) or corrupt the running job (unconditional delete).

## Test plan
- [x] All 37 telegram poller tests pass
- [x] Verified polling loop cycles correctly in production (offsets advancing)
- [x] Confirmed bot responds to messages after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)