### PR TITLE
revert: switch sandbox rootfs back from Debian to Alpine

### DIFF
--- a/platform/components/sandboxed_backend.py
+++ b/platform/components/sandboxed_backend.py
@@ -5,7 +5,7 @@ shell commands run inside an isolated namespace.
 
 Three execution modes:
 
-- **bwrap**: Debian rootfs mounted as ``/``, workspace bound at ``/workspace``,
+- **bwrap**: Alpine rootfs mounted as ``/``, workspace bound at ``/workspace``,
   ``--clearenv`` with explicit env vars.  Full filesystem isolation.
 - **container**: Already inside Docker/Codespaces/etc — scrubs env vars and
   runs with a clean ``PATH``/``HOME``.
@@ -61,7 +61,7 @@ def _build_bwrap_command(
     extra_ro_binds: list[tuple[str, str]] | None = None,
     allow_network: bool = False,
 ) -> list[str]:
-    """Build a bwrap command line for Linux sandboxing with Debian rootfs.
+    """Build a bwrap command line for Linux sandboxing with Alpine rootfs.
 
     The rootfs is mounted as ``/`` (rw), the workspace data at ``/workspace``
     (rw), and ``workspace/.tmp`` at ``/tmp`` (persistent temp).  ``--clearenv``
@@ -73,7 +73,7 @@ def _build_bwrap_command(
 
     args = ["bwrap", "--unshare-all"]
 
-    # Rootfs as root (rw)
+    # Rootfs as root (rw — apk cache, etc.)
     args += ["--bind", workspace_rootfs, "/"]
 
     # Workspace data
@@ -207,7 +207,7 @@ class SandboxedShellBackend(LocalShellBackend):
         workspace: str,
         effective_timeout: int,
     ) -> ExecuteResponse:
-        """Execute a command inside a bwrap sandbox with Debian rootfs."""
+        """Execute a command inside a bwrap sandbox with Alpine rootfs."""
         rootfs = self._ensure_workspace_rootfs(workspace)
 
         sandbox_cmd = _build_bwrap_command(

--- a/platform/services/environment.py
+++ b/platform/services/environment.py
@@ -208,7 +208,7 @@ def _detect_network() -> dict:
     # DNS check
     try:
         result = subprocess.run(
-            ["getent", "hosts", "github.com"],
+            ["getent", "hosts", "dl-cdn.alpinelinux.org"],
             capture_output=True,
             timeout=_SUBPROCESS_TIMEOUT,
         )
@@ -222,10 +222,10 @@ def _detect_network() -> dict:
             try:
                 if cmd == "curl":
                     args = ["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
-                            "--max-time", "3", "https://github.com/"]
+                            "--max-time", "3", "https://dl-cdn.alpinelinux.org/alpine/"]
                 else:
                     args = ["wget", "-q", "--spider", "--timeout=3",
-                            "https://github.com/"]
+                            "https://dl-cdn.alpinelinux.org/alpine/"]
                 result = subprocess.run(args, capture_output=True, timeout=_SUBPROCESS_TIMEOUT + 2)
                 network["http"] = result.returncode == 0
             except (subprocess.TimeoutExpired, OSError):

--- a/platform/services/rootfs.py
+++ b/platform/services/rootfs.py
@@ -1,9 +1,8 @@
-"""Debian rootfs golden image provisioning and per-workspace copy.
+"""Alpine rootfs golden image provisioning and per-workspace copy.
 
-Downloads a pre-built Debian rootfs tarball from GitHub Releases, verifies
-its SHA-256 hash, extracts it, and copies the golden image to individual
-workspaces.  All packages are pre-installed in the tarball — no runtime
-package installation needed.
+Downloads an Alpine Linux minirootfs tarball, verifies its SHA-256 hash,
+extracts it, installs tier-1/tier-2 packages via ``apk`` inside a bwrap
+sandbox, and copies the resulting golden image to individual workspaces.
 """
 
 from __future__ import annotations
@@ -15,6 +14,7 @@ import os
 import platform
 import shutil
 import subprocess
+import tempfile
 import urllib.request
 from pathlib import Path
 
@@ -24,13 +24,24 @@ logger = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-ROOTFS_REPO = "theuselessai/debian-rootfs"
-ROOTFS_VERSION = "v2"
+ALPINE_CDN = "https://dl-cdn.alpinelinux.org/alpine"
+
+TIER1_PACKAGES: list[str] = [
+    "bash", "python3", "py3-pip", "coreutils", "grep", "sed",
+]
+
+TIER2_PACKAGES: list[str] = [
+    "findutils", "curl", "wget", "git", "tar", "unzip", "jq",
+    "gawk", "nodejs", "npm",
+]
 
 ARCH_MAP: dict[str, str] = {
-    "x86_64": "amd64",
-    "aarch64": "arm64",
-    "arm64": "arm64",
+    "x86_64": "x86_64",
+    "aarch64": "aarch64",
+    "arm64": "aarch64",
+    "armv7l": "armv7",
+    "i686": "x86",
+    "i386": "x86",
 }
 
 
@@ -40,7 +51,7 @@ ARCH_MAP: dict[str, str] = {
 
 
 def detect_arch() -> str:
-    """Map ``platform.machine()`` to a Debian architecture string.
+    """Map ``platform.machine()`` to an Alpine architecture string.
 
     Raises ``RuntimeError`` if the current architecture is not supported.
     """
@@ -52,6 +63,69 @@ def detect_arch() -> str:
             f"Supported: {', '.join(sorted(ARCH_MAP.keys()))}"
         )
     return arch
+
+
+# ---------------------------------------------------------------------------
+# Latest version discovery
+# ---------------------------------------------------------------------------
+
+
+def get_latest_version(arch: str) -> tuple[str, str, str]:
+    """Fetch the latest Alpine minirootfs version from the CDN.
+
+    Parses ``latest-releases.yaml`` with simple line-by-line parsing
+    (no pyyaml dependency).
+
+    Returns
+    -------
+    tuple[str, str, str]
+        ``(version, filename, sha256)`` for the latest minirootfs.
+
+    Raises
+    ------
+    RuntimeError
+        If no minirootfs entry is found in the YAML.
+    """
+    url = f"{ALPINE_CDN}/latest-stable/releases/{arch}/latest-releases.yaml"
+    logger.info("Fetching Alpine release info from %s", url)
+
+    req = urllib.request.Request(url, headers={"User-Agent": "pipelit-rootfs/1.0"})
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        text = resp.read().decode("utf-8")
+
+    # Parse YAML looking for flavor: alpine-minirootfs blocks
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("-"):
+            if current:
+                entries.append(current)
+            current = {}
+            # Handle "- key: value" format
+            rest = stripped.lstrip("- ").strip()
+            if ":" in rest:
+                k, v = rest.split(":", 1)
+                current[k.strip()] = v.strip().strip('"').strip("'")
+        elif ":" in stripped and current is not None:
+            k, v = stripped.split(":", 1)
+            current[k.strip()] = v.strip().strip('"').strip("'")
+    if current:
+        entries.append(current)
+
+    # Find the minirootfs entry
+    for entry in entries:
+        flavor = entry.get("flavor", "")
+        if "minirootfs" in flavor:
+            version = entry.get("version", "")
+            filename = entry.get("file", "")
+            sha256 = entry.get("sha256", "")
+            if version and filename and sha256:
+                return version, filename, sha256
+
+    raise RuntimeError(
+        f"No minirootfs entry found in Alpine latest-releases.yaml for {arch}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -72,14 +146,14 @@ def get_golden_dir() -> Path:
 
 
 def is_rootfs_ready(rootfs_dir: Path) -> bool:
-    """Check whether a rootfs directory contains a usable Debian rootfs.
+    """Check whether a rootfs directory contains a usable Alpine rootfs.
 
-    Checks for ``/bin/sh``, ``/usr/bin/python3``, and ``/etc/debian_version``.
+    Checks for ``/bin/sh``, ``/usr/bin/python3``, and ``/etc/alpine-release``.
     """
     return (
         (rootfs_dir / "bin" / "sh").exists()
         and (rootfs_dir / "usr" / "bin" / "python3").exists()
-        and (rootfs_dir / "etc" / "debian_version").exists()
+        and (rootfs_dir / "etc" / "alpine-release").exists()
     )
 
 
@@ -89,35 +163,24 @@ def is_rootfs_ready(rootfs_dir: Path) -> bool:
 
 
 def download_rootfs(target_dir: Path, arch: str) -> Path:
-    """Download the Debian rootfs tarball and verify its SHA-256 hash.
+    """Download the Alpine minirootfs tarball and verify its SHA-256 hash.
 
     Returns the path to the downloaded tarball.
 
     Raises ``RuntimeError`` on checksum mismatch or network error.
     """
-    base_url = f"https://github.com/{ROOTFS_REPO}/releases/download/{ROOTFS_VERSION}"
-    filename = f"debian-rootfs-{arch}.tar.gz"
+    version, filename, expected_sha256 = get_latest_version(arch)
+    url = f"{ALPINE_CDN}/latest-stable/releases/{arch}/{filename}"
     tarball_path = target_dir / filename
 
-    # Download checksum
-    sha256_url = f"{base_url}/{filename}.sha256"
-    logger.info("Fetching checksum from %s", sha256_url)
-    req = urllib.request.Request(sha256_url, headers={"User-Agent": "pipelit-rootfs/1.0"})
-    try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            expected_sha256 = resp.read().decode("utf-8").strip().split()[0]
-    except Exception as exc:
-        raise RuntimeError(f"Failed to download checksum from {sha256_url}: {exc}") from exc
+    logger.info("Downloading Alpine rootfs %s from %s", version, url)
 
-    # Download tarball
-    tarball_url = f"{base_url}/{filename}"
-    logger.info("Downloading Debian rootfs %s from %s", ROOTFS_VERSION, tarball_url)
-    req = urllib.request.Request(tarball_url, headers={"User-Agent": "pipelit-rootfs/1.0"})
+    req = urllib.request.Request(url, headers={"User-Agent": "pipelit-rootfs/1.0"})
     try:
-        with urllib.request.urlopen(req, timeout=300) as resp:
+        with urllib.request.urlopen(req, timeout=120) as resp:
             data = resp.read()
     except Exception as exc:
-        raise RuntimeError(f"Failed to download rootfs from {tarball_url}: {exc}") from exc
+        raise RuntimeError(f"Failed to download rootfs from {url}: {exc}") from exc
 
     # Verify SHA-256
     actual_sha256 = hashlib.sha256(data).hexdigest()
@@ -133,15 +196,57 @@ def download_rootfs(target_dir: Path, arch: str) -> Path:
 
 
 def extract_rootfs(tarball: Path, target_dir: Path) -> None:
-    """Extract a rootfs tarball into the target directory."""
+    """Extract a minirootfs tarball into the target directory."""
     logger.info("Extracting %s to %s", tarball, target_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
     subprocess.run(
         ["tar", "xzf", str(tarball), "-C", str(target_dir)],
         check=True,
         capture_output=True,
-        timeout=120,
+        timeout=60,
     )
+
+
+# ---------------------------------------------------------------------------
+# Package installation
+# ---------------------------------------------------------------------------
+
+
+def install_packages(rootfs_dir: Path, packages: list[str]) -> None:
+    """Install packages into the rootfs using apk via bwrap.
+
+    Uses bwrap to run ``apk add`` inside the rootfs without requiring
+    actual chroot privileges.
+
+    Raises ``RuntimeError`` if package installation fails.
+    """
+    if not packages:
+        return
+
+    logger.info("Installing packages in rootfs: %s", ", ".join(packages))
+
+    cmd = [
+        "bwrap",
+        "--bind", str(rootfs_dir), "/",
+        "--dev", "/dev",
+        "--proc", "/proc",
+        "--ro-bind", "/etc/resolv.conf", "/etc/resolv.conf",
+        "--share-net",
+        "--die-with-parent",
+        "--clearenv",
+        "--setenv", "PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "--chdir", "/",
+        "--",
+        "apk", "add", "--no-cache",
+    ] + packages
+
+    result = subprocess.run(cmd, capture_output=True, timeout=300)
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"apk add failed (exit {result.returncode}): {stderr}"
+        )
+    logger.info("Package installation complete")
 
 
 # ---------------------------------------------------------------------------
@@ -177,12 +282,14 @@ def _ensure_var_tmp_symlink(rootfs_dir: Path) -> None:
 
 
 def prepare_golden_image(tier: int = 1) -> Path:
-    """Prepare the golden Debian rootfs image. Idempotent.
+    """Prepare the golden Alpine rootfs image. Idempotent.
 
     Uses ``fcntl.flock()`` for concurrency safety across workers.
 
-    The ``tier`` parameter is accepted for API compatibility but ignored —
-    all packages are pre-installed in the tarball.
+    Parameters
+    ----------
+    tier : int
+        Package tier: 1 for TIER1_PACKAGES only, 2 for both tiers.
 
     Returns the path to the golden rootfs directory.
     """
@@ -206,12 +313,6 @@ def prepare_golden_image(tier: int = 1) -> Path:
                 logger.info("Golden rootfs ready (created by another worker)")
                 return golden_dir
 
-            # Clean up old rootfs (e.g. Alpine → Debian migration)
-            if golden_dir.exists():
-                logger.info("Removing old rootfs at %s", golden_dir)
-                shutil.rmtree(golden_dir)
-                golden_dir.mkdir(parents=True, exist_ok=True)
-
             arch = detect_arch()
 
             # Download
@@ -221,13 +322,19 @@ def prepare_golden_image(tier: int = 1) -> Path:
                 # Extract
                 extract_rootfs(tarball, golden_dir)
 
+                # Install packages
+                packages = list(TIER1_PACKAGES)
+                if tier >= 2:
+                    packages += TIER2_PACKAGES
+                install_packages(golden_dir, packages)
+
                 # /var/tmp symlink
                 _ensure_var_tmp_symlink(golden_dir)
 
                 if not is_rootfs_ready(golden_dir):
                     raise RuntimeError(
                         f"Golden rootfs at {golden_dir} failed readiness check after provisioning. "
-                        f"Expected bin/sh, usr/bin/python3, and etc/debian_version."
+                        f"Expected bin/sh, usr/bin/python3, and etc/alpine-release."
                     )
 
                 logger.info("Golden rootfs prepared at %s", golden_dir)

--- a/platform/tests/test_rootfs.py
+++ b/platform/tests/test_rootfs.py
@@ -1,11 +1,11 @@
-"""Tests for services.rootfs — Debian rootfs provisioning and per-workspace copy."""
+"""Tests for services.rootfs — Alpine rootfs provisioning and per-workspace copy."""
 
 from __future__ import annotations
 
-import hashlib
 import os
+from io import BytesIO
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, mock_open
 
 import pytest
 
@@ -21,16 +21,6 @@ def _isolate_pipelit_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("PIPELIT_DIR", str(tmp_path / "pipelit"))
 
 
-def _make_debian_rootfs(rootfs_dir: Path) -> None:
-    """Create a minimal Debian rootfs structure for testing."""
-    (rootfs_dir / "bin").mkdir(parents=True, exist_ok=True)
-    (rootfs_dir / "bin" / "sh").touch()
-    (rootfs_dir / "usr" / "bin").mkdir(parents=True, exist_ok=True)
-    (rootfs_dir / "usr" / "bin" / "python3").touch()
-    (rootfs_dir / "etc").mkdir(parents=True, exist_ok=True)
-    (rootfs_dir / "etc" / "debian_version").write_text("12.13")
-
-
 # ---------------------------------------------------------------------------
 # detect_arch
 # ---------------------------------------------------------------------------
@@ -41,19 +31,19 @@ class TestDetectArch:
         from services.rootfs import detect_arch
 
         with patch("platform.machine", return_value="x86_64"):
-            assert detect_arch() == "amd64"
+            assert detect_arch() == "x86_64"
 
     def test_aarch64(self):
         from services.rootfs import detect_arch
 
         with patch("platform.machine", return_value="aarch64"):
-            assert detect_arch() == "arm64"
+            assert detect_arch() == "aarch64"
 
-    def test_arm64_maps_to_arm64(self):
+    def test_arm64_maps_to_aarch64(self):
         from services.rootfs import detect_arch
 
         with patch("platform.machine", return_value="arm64"):
-            assert detect_arch() == "arm64"
+            assert detect_arch() == "aarch64"
 
     def test_unsupported_raises(self):
         from services.rootfs import detect_arch
@@ -61,6 +51,59 @@ class TestDetectArch:
         with patch("platform.machine", return_value="mips64"):
             with pytest.raises(RuntimeError, match="Unsupported architecture"):
                 detect_arch()
+
+
+# ---------------------------------------------------------------------------
+# get_latest_version
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_YAML = """\
+---
+- flavor: alpine-minirootfs
+  version: "3.21.3"
+  file: alpine-minirootfs-3.21.3-x86_64.tar.gz
+  sha256: abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+- flavor: alpine-standard
+  version: "3.21.3"
+  file: alpine-standard-3.21.3-x86_64.iso
+  sha256: 1111111111111111111111111111111111111111111111111111111111111111
+"""
+
+
+class TestGetLatestVersion:
+    def test_parses_yaml(self):
+        from services.rootfs import get_latest_version
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = SAMPLE_YAML.encode("utf-8")
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            version, filename, sha256 = get_latest_version("x86_64")
+
+        assert version == "3.21.3"
+        assert "minirootfs" in filename
+        assert sha256 == "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+    def test_no_minirootfs_raises(self):
+        from services.rootfs import get_latest_version
+
+        yaml_no_mini = """\
+- flavor: alpine-standard
+  version: "3.21.3"
+  file: alpine-standard-3.21.3-x86_64.iso
+  sha256: 1111111111111111111111111111111111111111111111111111111111111111
+"""
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = yaml_no_mini.encode("utf-8")
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp):
+            with pytest.raises(RuntimeError, match="No minirootfs"):
+                get_latest_version("x86_64")
 
 
 # ---------------------------------------------------------------------------
@@ -73,7 +116,13 @@ class TestRootfsReadiness:
         from services.rootfs import is_rootfs_ready
 
         rootfs = tmp_path / "rootfs"
-        _make_debian_rootfs(rootfs)
+        (rootfs / "bin").mkdir(parents=True)
+        (rootfs / "bin" / "sh").touch()
+        (rootfs / "usr" / "bin").mkdir(parents=True)
+        (rootfs / "usr" / "bin" / "python3").touch()
+        (rootfs / "etc").mkdir(parents=True)
+        (rootfs / "etc" / "alpine-release").write_text("3.21.3")
+
         assert is_rootfs_ready(rootfs) is True
 
     def test_empty_dir(self, tmp_path):
@@ -90,7 +139,8 @@ class TestRootfsReadiness:
         (rootfs / "bin").mkdir(parents=True)
         (rootfs / "bin" / "sh").touch()
         (rootfs / "etc").mkdir(parents=True)
-        (rootfs / "etc" / "debian_version").write_text("12.13")
+        (rootfs / "etc" / "alpine-release").write_text("3.21.3")
+
         assert is_rootfs_ready(rootfs) is False
 
     def test_no_version_file(self, tmp_path):
@@ -101,19 +151,7 @@ class TestRootfsReadiness:
         (rootfs / "bin" / "sh").touch()
         (rootfs / "usr" / "bin").mkdir(parents=True)
         (rootfs / "usr" / "bin" / "python3").touch()
-        assert is_rootfs_ready(rootfs) is False
 
-    def test_alpine_rootfs_not_ready(self, tmp_path):
-        """Old Alpine rootfs should fail the readiness check."""
-        from services.rootfs import is_rootfs_ready
-
-        rootfs = tmp_path / "rootfs"
-        (rootfs / "bin").mkdir(parents=True)
-        (rootfs / "bin" / "sh").touch()
-        (rootfs / "usr" / "bin").mkdir(parents=True)
-        (rootfs / "usr" / "bin" / "python3").touch()
-        (rootfs / "etc").mkdir(parents=True)
-        (rootfs / "etc" / "alpine-release").write_text("3.21.3")
         assert is_rootfs_ready(rootfs) is False
 
 
@@ -124,31 +162,23 @@ class TestRootfsReadiness:
 
 class TestDownloadRootfs:
     def test_success(self, tmp_path):
+        import hashlib
         from services.rootfs import download_rootfs
 
         data = b"fake tarball data"
         sha256 = hashlib.sha256(data).hexdigest()
 
-        call_count = [0]
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = data
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
 
-        def mock_urlopen(req, **kwargs):
-            mock_resp = MagicMock()
-            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
-            mock_resp.__exit__ = MagicMock(return_value=False)
-            if call_count[0] == 0:
-                # First call: checksum file
-                mock_resp.read.return_value = f"{sha256}  debian-rootfs-amd64.tar.gz\n".encode()
-            else:
-                # Second call: tarball
-                mock_resp.read.return_value = data
-            call_count[0] += 1
-            return mock_resp
-
-        with patch("urllib.request.urlopen", side_effect=mock_urlopen):
-            result = download_rootfs(tmp_path, "amd64")
+        with patch("services.rootfs.get_latest_version", return_value=("3.21", "mini.tar.gz", sha256)), \
+             patch("urllib.request.urlopen", return_value=mock_resp):
+            result = download_rootfs(tmp_path, "x86_64")
 
         assert result.exists()
-        assert result.name == "debian-rootfs-amd64.tar.gz"
+        assert result.name == "mini.tar.gz"
         assert result.read_bytes() == data
 
     def test_checksum_mismatch(self, tmp_path):
@@ -156,48 +186,57 @@ class TestDownloadRootfs:
 
         data = b"fake tarball data"
 
-        call_count = [0]
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = data
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
 
-        def mock_urlopen(req, **kwargs):
-            mock_resp = MagicMock()
-            mock_resp.__enter__ = MagicMock(return_value=mock_resp)
-            mock_resp.__exit__ = MagicMock(return_value=False)
-            if call_count[0] == 0:
-                mock_resp.read.return_value = b"badhash  debian-rootfs-amd64.tar.gz\n"
-            else:
-                mock_resp.read.return_value = data
-            call_count[0] += 1
-            return mock_resp
-
-        with patch("urllib.request.urlopen", side_effect=mock_urlopen):
+        with patch("services.rootfs.get_latest_version", return_value=("3.21", "mini.tar.gz", "badhash")), \
+             patch("urllib.request.urlopen", return_value=mock_resp):
             with pytest.raises(RuntimeError, match="SHA-256 mismatch"):
-                download_rootfs(tmp_path, "amd64")
+                download_rootfs(tmp_path, "x86_64")
 
-    def test_network_error_on_checksum(self, tmp_path):
+    def test_network_error(self, tmp_path):
         from services.rootfs import download_rootfs
 
-        with patch("urllib.request.urlopen", side_effect=OSError("Connection refused")):
-            with pytest.raises(RuntimeError, match="Failed to download checksum"):
-                download_rootfs(tmp_path, "amd64")
+        with patch("services.rootfs.get_latest_version", return_value=("3.21", "mini.tar.gz", "abc")), \
+             patch("urllib.request.urlopen", side_effect=OSError("Connection refused")):
+            with pytest.raises(RuntimeError, match="Failed to download"):
+                download_rootfs(tmp_path, "x86_64")
 
-    def test_network_error_on_tarball(self, tmp_path):
-        from services.rootfs import download_rootfs
 
-        call_count = [0]
+# ---------------------------------------------------------------------------
+# install_packages
+# ---------------------------------------------------------------------------
 
-        def mock_urlopen(req, **kwargs):
-            if call_count[0] == 0:
-                call_count[0] += 1
-                mock_resp = MagicMock()
-                mock_resp.__enter__ = MagicMock(return_value=mock_resp)
-                mock_resp.__exit__ = MagicMock(return_value=False)
-                mock_resp.read.return_value = b"abc123  debian-rootfs-amd64.tar.gz\n"
-                return mock_resp
-            raise OSError("Connection refused")
 
-        with patch("urllib.request.urlopen", side_effect=mock_urlopen):
-            with pytest.raises(RuntimeError, match="Failed to download rootfs"):
-                download_rootfs(tmp_path, "amd64")
+class TestInstallPackages:
+    def test_calls_bwrap_correctly(self, tmp_path):
+        from services.rootfs import install_packages
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            install_packages(tmp_path / "rootfs", ["bash", "python3"])
+
+        args = mock_run.call_args[0][0]
+        assert args[0] == "bwrap"
+        assert "--bind" in args
+        assert "--share-net" in args
+        assert "apk" in args
+        assert "add" in args
+        assert "--no-cache" in args
+        assert "bash" in args
+        assert "python3" in args
+
+    def test_failure_raises(self, tmp_path):
+        from services.rootfs import install_packages
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1, stderr=b"ERROR: package not found"
+            )
+            with pytest.raises(RuntimeError, match="apk add failed"):
+                install_packages(tmp_path / "rootfs", ["nonexistent-pkg"])
 
 
 # ---------------------------------------------------------------------------
@@ -248,44 +287,10 @@ class TestVarTmpSymlink:
 
 
 class TestPrepareGoldenImage:
-    def test_idempotent_skip(self, tmp_path):
+    def test_idempotent_skip(self, tmp_path, monkeypatch):
         from services.rootfs import prepare_golden_image
 
         golden = tmp_path / "pipelit" / "rootfs"
-        _make_debian_rootfs(golden)
-
-        with patch("services.rootfs.get_golden_dir", return_value=golden):
-            result = prepare_golden_image()
-
-        assert result == golden
-
-    def test_downloads_when_missing(self, tmp_path):
-        from services.rootfs import prepare_golden_image
-
-        golden = tmp_path / "pipelit" / "rootfs"
-        tarball_path = tmp_path / "pipelit" / "debian-rootfs-amd64.tar.gz"
-
-        def fake_extract(tarball, target):
-            _make_debian_rootfs(target)
-
-        with patch("services.rootfs.get_golden_dir", return_value=golden), \
-             patch("services.rootfs.detect_arch", return_value="amd64"), \
-             patch("services.rootfs.download_rootfs", return_value=tarball_path) as mock_dl, \
-             patch("services.rootfs.extract_rootfs", side_effect=fake_extract) as mock_extract:
-            golden.parent.mkdir(parents=True, exist_ok=True)
-            tarball_path.touch()
-            result = prepare_golden_image()
-
-        mock_dl.assert_called_once()
-        mock_extract.assert_called_once()
-        assert result == golden
-
-    def test_removes_old_rootfs(self, tmp_path):
-        """Old Alpine rootfs should be removed and replaced with Debian."""
-        from services.rootfs import prepare_golden_image
-
-        golden = tmp_path / "pipelit" / "rootfs"
-        # Create an old Alpine rootfs
         (golden / "bin").mkdir(parents=True)
         (golden / "bin" / "sh").touch()
         (golden / "usr" / "bin").mkdir(parents=True)
@@ -293,35 +298,62 @@ class TestPrepareGoldenImage:
         (golden / "etc").mkdir(parents=True)
         (golden / "etc" / "alpine-release").write_text("3.21.3")
 
-        tarball_path = tmp_path / "pipelit" / "debian-rootfs-amd64.tar.gz"
-
-        def fake_extract(tarball, target):
-            _make_debian_rootfs(target)
-
-        with patch("services.rootfs.get_golden_dir", return_value=golden), \
-             patch("services.rootfs.detect_arch", return_value="amd64"), \
-             patch("services.rootfs.download_rootfs", return_value=tarball_path), \
-             patch("services.rootfs.extract_rootfs", side_effect=fake_extract):
-            tarball_path.touch()
+        with patch("services.rootfs.get_golden_dir", return_value=golden):
             result = prepare_golden_image()
 
         assert result == golden
-        assert (golden / "etc" / "debian_version").exists()
-        assert not (golden / "etc" / "alpine-release").exists()
 
-    def test_uses_flock(self, tmp_path):
+    def test_downloads_when_missing(self, tmp_path, monkeypatch):
         from services.rootfs import prepare_golden_image
 
         golden = tmp_path / "pipelit" / "rootfs"
-        tarball_path = tmp_path / "pipelit" / "debian-rootfs-amd64.tar.gz"
 
         def fake_extract(tarball, target):
-            _make_debian_rootfs(target)
+            # Simulate extraction creating the rootfs structure
+            (target / "bin").mkdir(parents=True, exist_ok=True)
+            (target / "bin" / "sh").touch()
+            (target / "usr" / "bin").mkdir(parents=True, exist_ok=True)
+            (target / "usr" / "bin" / "python3").touch()
+            (target / "etc").mkdir(parents=True, exist_ok=True)
+            (target / "etc" / "alpine-release").write_text("3.21.3")
+
+        tarball_path = tmp_path / "pipelit" / "mini.tar.gz"
 
         with patch("services.rootfs.get_golden_dir", return_value=golden), \
-             patch("services.rootfs.detect_arch", return_value="amd64"), \
+             patch("services.rootfs.detect_arch", return_value="x86_64"), \
+             patch("services.rootfs.download_rootfs", return_value=tarball_path) as mock_dl, \
+             patch("services.rootfs.extract_rootfs", side_effect=fake_extract) as mock_extract, \
+             patch("services.rootfs.install_packages") as mock_install:
+            # Create the tarball so unlink works
+            golden.parent.mkdir(parents=True, exist_ok=True)
+            tarball_path.touch()
+            result = prepare_golden_image()
+
+        mock_dl.assert_called_once()
+        mock_extract.assert_called_once()
+        mock_install.assert_called_once()
+        assert result == golden
+
+    def test_uses_flock(self, tmp_path, monkeypatch):
+        from services.rootfs import prepare_golden_image
+
+        golden = tmp_path / "pipelit" / "rootfs"
+
+        def fake_extract(tarball, target):
+            (target / "bin").mkdir(parents=True, exist_ok=True)
+            (target / "bin" / "sh").touch()
+            (target / "usr" / "bin").mkdir(parents=True, exist_ok=True)
+            (target / "usr" / "bin" / "python3").touch()
+            (target / "etc").mkdir(parents=True, exist_ok=True)
+            (target / "etc" / "alpine-release").write_text("3.21.3")
+
+        tarball_path = tmp_path / "pipelit" / "mini.tar.gz"
+
+        with patch("services.rootfs.get_golden_dir", return_value=golden), \
+             patch("services.rootfs.detect_arch", return_value="x86_64"), \
              patch("services.rootfs.download_rootfs", return_value=tarball_path), \
              patch("services.rootfs.extract_rootfs", side_effect=fake_extract), \
+             patch("services.rootfs.install_packages"), \
              patch("fcntl.flock") as mock_flock:
             golden.parent.mkdir(parents=True, exist_ok=True)
             tarball_path.touch()
@@ -339,7 +371,12 @@ class TestPrepareGoldenImage:
 class TestCopyRootfsToWorkspace:
     def _make_golden(self, tmp_path):
         golden = tmp_path / "golden"
-        _make_debian_rootfs(golden)
+        (golden / "bin").mkdir(parents=True)
+        (golden / "bin" / "sh").touch()
+        (golden / "usr" / "bin").mkdir(parents=True)
+        (golden / "usr" / "bin" / "python3").touch()
+        (golden / "etc").mkdir(parents=True)
+        (golden / "etc" / "alpine-release").write_text("3.21.3")
         return golden
 
     def test_creates_rootfs(self, tmp_path):
@@ -366,26 +403,6 @@ class TestCopyRootfsToWorkspace:
         copy_rootfs_to_workspace(golden, str(workspace))  # Should not raise
 
         assert (workspace / ".rootfs" / "bin" / "sh").exists()
-
-    def test_replaces_alpine_rootfs(self, tmp_path):
-        """Workspace with old Alpine rootfs should be replaced."""
-        from services.rootfs import copy_rootfs_to_workspace
-
-        golden = self._make_golden(tmp_path)
-        workspace = tmp_path / "workspace"
-        workspace.mkdir()
-
-        # Create old Alpine rootfs in workspace
-        old_rootfs = workspace / ".rootfs"
-        (old_rootfs / "bin").mkdir(parents=True)
-        (old_rootfs / "bin" / "sh").touch()
-        (old_rootfs / "etc").mkdir(parents=True)
-        (old_rootfs / "etc" / "alpine-release").write_text("3.21.3")
-
-        result = copy_rootfs_to_workspace(golden, str(workspace))
-
-        assert (result / "etc" / "debian_version").exists()
-        assert not (result / "etc" / "alpine-release").exists()
 
     def test_creates_tmp(self, tmp_path):
         from services.rootfs import copy_rootfs_to_workspace

--- a/platform/tests/test_sandboxed_backend.py
+++ b/platform/tests/test_sandboxed_backend.py
@@ -389,7 +389,7 @@ class TestSandboxedExecution:
     """Integration tests using real bwrap with mocked rootfs provisioning.
 
     These tests create a minimal rootfs from the host system for testing
-    purposes, since we can't download the Debian rootfs in CI.
+    purposes, since we can't download Alpine in CI.
     """
 
     @pytest.fixture


### PR DESCRIPTION
## Summary
- Reverts `fa1d983` (Debian rootfs switch)
- Debian's `apt` doesn't work inside bwrap's user namespace — postinstall scripts need `adduser`/`chown` to unmapped uids, which the kernel rejects
- Alpine's `apk` works fine in the sandbox, and a musl-compatible agent-browser build removes the original motivation for Debian

## Test plan
- [x] `pytest tests/test_rootfs.py tests/test_sandboxed_backend.py` — 65 tests pass
- [x] Cleared cached rootfs, restarted honcho, triggered deep agent execution
- [x] Alpine minirootfs downloads and `apk add` succeeds inside bwrap sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)