### PR TITLE
feat(cli): add --base-url to apply-fixture command

### DIFF
--- a/platform/cli/__main__.py
+++ b/platform/cli/__main__.py
@@ -120,6 +120,7 @@ def cmd_apply_fixture(args: argparse.Namespace) -> None:
             base_credentials_id=base_cred.id,
             provider_type=args.provider,
             api_key=args.api_key,
+            base_url=args.base_url or "",
         )
         db.add(llm_cred)
         db.flush()
@@ -303,6 +304,7 @@ def main() -> None:
         default=os.environ.get("PIPELIT_LLM_API_KEY"),
         help="LLM provider API key (or set PIPELIT_LLM_API_KEY env var)",
     )
+    sp_fixture.add_argument("--base-url", default=None, help="LLM provider base URL")
 
     args = parser.parse_args()
 

--- a/platform/tests/test_cli.py
+++ b/platform/tests/test_cli.py
@@ -206,6 +206,29 @@ class TestCLIApplyFixture:
         assert llm_cred is not None
         assert llm_cred.provider_type == "venice"
 
+    def test_apply_fixture_base_url(self, cli_db, user_profile):
+        _run_cli([
+            "apply-fixture", "default-agent",
+            "--provider", "ollama", "--model", "llama3",
+            "--api-key", "sk-test", "--base-url", "http://localhost:11434/v1",
+        ])
+
+        from models.credential import LLMProviderCredential
+        llm_cred = cli_db.query(LLMProviderCredential).first()
+        assert llm_cred is not None
+        assert llm_cred.base_url == "http://localhost:11434/v1"
+
+    def test_apply_fixture_base_url_defaults_empty(self, cli_db, user_profile):
+        _run_cli([
+            "apply-fixture", "default-agent",
+            "--provider", "openai", "--model", "gpt-4o", "--api-key", "sk-test",
+        ])
+
+        from models.credential import LLMProviderCredential
+        llm_cred = cli_db.query(LLMProviderCredential).first()
+        assert llm_cred is not None
+        assert llm_cred.base_url == ""
+
     def test_apply_fixture_idempotent(self, cli_db, user_profile):
         _run_cli([
             "apply-fixture", "default-agent",


### PR DESCRIPTION
## Summary

Closes #145. Adds `--base-url` optional argument to `cli apply-fixture` for LLM providers that need a custom endpoint (Ollama, OpenAI-compatible).

- Pass `--base-url http://localhost:11434/v1` to set the provider endpoint
- Defaults to empty string when omitted (standard provider default)
- 2 new tests: explicit base URL + default empty

```bash
python -m cli apply-fixture default-agent \
  --provider ollama --model llama3 \
  --api-key unused --base-url http://localhost:11434/v1
```

Unblocks msg-gateway #54 (base URL passthrough in `plit init`).