### PR TITLE
fix: link ai_model to deep_agent in default fixture

### DIFF
--- a/platform/cli/__main__.py
+++ b/platform/cli/__main__.py
@@ -168,6 +168,7 @@ def cmd_apply_fixture(args: argparse.Namespace) -> None:
 
         agent_cfg = BaseComponentConfig(
             component_type="deep_agent",
+            llm_model_config_id=model_cfg.id,
             extra_config={"conversation_memory": True},
         )
         db.add(agent_cfg)


### PR DESCRIPTION
## Summary

The default-agent fixture creates edges between ai_model and deep_agent nodes, but the LLM resolver (`resolve_llm_for_node`) uses `llm_model_config_id` FK on the component config — not edge traversal.

Without this FK set, `plit start` → chat produces:
```
ValueError: Node 'deep_agent_1' has no connected ai_model node via edge_label='llm'.
```

One-line fix: add `llm_model_config_id=model_cfg.id` to the deep_agent config.