### PR TITLE
fix: enable network access in default workspace

### DIFF
--- a/platform/cli/__main__.py
+++ b/platform/cli/__main__.py
@@ -58,7 +58,7 @@ def cmd_setup(args: argparse.Namespace) -> None:
         workspace_path = str(get_pipelit_dir() / "workspaces" / "default")
         os.makedirs(workspace_path, exist_ok=True)
         os.makedirs(os.path.join(workspace_path, ".tmp"), exist_ok=True)
-        ws = Workspace(name="default", path=workspace_path, user_profile_id=user.id)
+        ws = Workspace(name="default", path=workspace_path, user_profile_id=user.id, allow_network=True)
         db.add(ws)
         db.commit()
 


### PR DESCRIPTION
## Summary
- Set `allow_network=True` on the default workspace created during `plit init` so the bwrap sandbox has network access out of the box

Closes #149

**Note:** #143 (remove frontend setup wizard) was already completed in #144 (commit b261703) and can be closed.

## Test plan
- [ ] Run `plit init` and verify the default workspace has `allow_network=True`
- [ ] Run `plit chat` and confirm the deep agent can resolve DNS and reach external APIs inside the sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)