### PR TITLE
feat: user management API with multi-key system

### DIFF
--- a/platform/alembic/versions/c5d6e7f8a9b0_multi_key_api_key_management.py
+++ b/platform/alembic/versions/c5d6e7f8a9b0_multi_key_api_key_management.py
@@ -1,0 +1,60 @@
+"""multi_key_api_key_management
+
+Revision ID: c5d6e7f8a9b0
+Revises: b4c2e8f1a903
+Create Date: 2026-03-13 00:00:00.000000
+
+Migrate APIKey from 1:1 to many-to-one with UserProfile.
+Add name, prefix, last_used_at, expires_at, is_active columns.
+Existing keys get name='default' and prefix from first 8 chars of key.
+Drop unique constraint on user_id.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+from sqlalchemy import text
+import sqlalchemy as sa
+
+
+revision: str = "c5d6e7f8a9b0"
+down_revision: Union[str, Sequence[str], None] = "b4c2e8f1a903"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    connection.execute(text("PRAGMA foreign_keys=OFF"))
+
+    # SQLite requires batch mode to alter constraints.
+    # We use batch_alter_table to recreate the table without the unique
+    # constraint on user_id, and add new columns.
+    with op.batch_alter_table("api_keys") as batch_op:
+        batch_op.add_column(sa.Column("name", sa.String(100), nullable=False, server_default="default"))
+        batch_op.add_column(sa.Column("prefix", sa.String(8), nullable=False, server_default=""))
+        batch_op.add_column(sa.Column("last_used_at", sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column("expires_at", sa.DateTime(), nullable=True))
+        batch_op.add_column(sa.Column("is_active", sa.Boolean(), nullable=False, server_default="1"))
+        # Drop the unique constraint on user_id (1:1 → many-to-one)
+        batch_op.drop_constraint("uq_api_keys_user_id", type_="unique")
+
+    # Backfill prefix from first 8 chars of existing key values
+    connection.execute(text("UPDATE api_keys SET prefix = SUBSTR(key, 1, 8) WHERE prefix = ''"))
+
+    connection.execute(text("PRAGMA foreign_keys=ON"))
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    connection.execute(text("PRAGMA foreign_keys=OFF"))
+
+    with op.batch_alter_table("api_keys") as batch_op:
+        batch_op.drop_column("name")
+        batch_op.drop_column("prefix")
+        batch_op.drop_column("last_used_at")
+        batch_op.drop_column("expires_at")
+        batch_op.drop_column("is_active")
+        batch_op.create_unique_constraint("uq_api_keys_user_id", ["user_id"])
+
+    connection.execute(text("PRAGMA foreign_keys=ON"))

--- a/platform/api/__init__.py
+++ b/platform/api/__init__.py
@@ -13,10 +13,12 @@ from api.tasks import router as tasks_router
 from api.schedules import router as schedules_router
 from api.workspaces import router as workspaces_router
 from api.settings import router as settings_router
+from api.users import users_router
 
 api_router = APIRouter(prefix="/api/v1")
 
 api_router.include_router(auth_router, prefix="/auth", tags=["auth"])
+api_router.include_router(users_router, prefix="/users", tags=["users"])
 api_router.include_router(workflows_router, prefix="/workflows", tags=["workflows"])
 api_router.include_router(nodes_router, prefix="/workflows", tags=["nodes", "edges"])
 api_router.include_router(executions_router, prefix="/executions", tags=["executions"])

--- a/platform/api/auth.py
+++ b/platform/api/auth.py
@@ -56,15 +56,25 @@ def obtain_token(payload: TokenRequest, db: Session = Depends(get_db)):
     if user.mfa_enabled:
         return {"key": "", "requires_mfa": True}
 
-    api_key = db.query(APIKey).filter(APIKey.user_id == user.id).first()
-    if api_key:
-        api_key.key = str(uuid.uuid4())
+    # Find or create a "session" key (login always rotates the session key)
+    session_key = (
+        db.query(APIKey)
+        .filter(APIKey.user_id == user.id, APIKey.name == "session")
+        .first()
+    )
+    if session_key:
+        session_key.key = str(uuid.uuid4())
+        session_key.prefix = session_key.key[:8]
+        session_key.is_active = True
     else:
-        api_key = APIKey(user_id=user.id, key=str(uuid.uuid4()))
-        db.add(api_key)
+        raw = str(uuid.uuid4())
+        session_key = APIKey(
+            user_id=user.id, key=raw, name="session", prefix=raw[:8],
+        )
+        db.add(session_key)
     db.commit()
-    db.refresh(api_key)
-    return {"key": api_key.key, "requires_mfa": False}
+    db.refresh(session_key)
+    return {"key": session_key.key, "requires_mfa": False}
 
 
 @router.get("/me/", response_model=MeResponse)
@@ -182,12 +192,22 @@ def mfa_login_verify(payload: MFALoginVerifyRequest, db: Session = Depends(get_d
     user.totp_last_used_at = step
     db.flush()  # Persist totp_last_used_at before API key update
 
-    api_key = db.query(APIKey).filter(APIKey.user_id == user.id).first()
-    if api_key:
-        api_key.key = str(uuid.uuid4())
+    # Find or create a "session" key (MFA login always rotates the session key)
+    session_key = (
+        db.query(APIKey)
+        .filter(APIKey.user_id == user.id, APIKey.name == "session")
+        .first()
+    )
+    if session_key:
+        session_key.key = str(uuid.uuid4())
+        session_key.prefix = session_key.key[:8]
+        session_key.is_active = True
     else:
-        api_key = APIKey(user_id=user.id, key=str(uuid.uuid4()))
-        db.add(api_key)
+        raw = str(uuid.uuid4())
+        session_key = APIKey(
+            user_id=user.id, key=raw, name="session", prefix=raw[:8],
+        )
+        db.add(session_key)
     db.commit()
-    db.refresh(api_key)
-    return {"key": api_key.key, "requires_mfa": False}
+    db.refresh(session_key)
+    return {"key": session_key.key, "requires_mfa": False}

--- a/platform/api/users.py
+++ b/platform/api/users.py
@@ -1,0 +1,291 @@
+"""User management + API key management endpoints."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+import bcrypt
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from auth import get_current_user, require_admin
+from database import get_db
+from models.user import APIKey, UserProfile, UserRole
+from schemas.users import (
+    APIKeyCreateIn,
+    APIKeyCreatedOut,
+    APIKeyOut,
+    SelfUpdateIn,
+    UserCreateIn,
+    UserListOut,
+    UserOut,
+    UserUpdateIn,
+)
+
+logger = logging.getLogger(__name__)
+
+users_router = APIRouter()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def _user_to_out(user: UserProfile, db: Session) -> UserOut:
+    key_count = db.query(APIKey).filter(
+        APIKey.user_id == user.id, APIKey.is_active == True  # noqa: E712
+    ).count()
+    return UserOut(
+        id=user.id,
+        username=user.username,
+        role=user.role,
+        first_name=user.first_name,
+        last_name=user.last_name,
+        created_at=user.created_at,
+        mfa_enabled=user.mfa_enabled,
+        key_count=key_count,
+    )
+
+
+def _create_api_key(
+    db: Session, user_id: int, name: str, expires_at: datetime | None = None,
+) -> APIKey:
+    raw_key = str(uuid.uuid4())
+    key = APIKey(
+        user_id=user_id,
+        key=raw_key,
+        name=name,
+        prefix=raw_key[:8],
+        expires_at=expires_at,
+    )
+    db.add(key)
+    db.commit()
+    db.refresh(key)
+    return key
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Self-service endpoints  (must be registered BEFORE /{user_id} routes)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@users_router.get("/me", response_model=UserOut)
+def get_own_profile(
+    user: UserProfile = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    return _user_to_out(user, db)
+
+
+@users_router.patch("/me", response_model=UserOut)
+def update_own_profile(
+    payload: SelfUpdateIn,
+    user: UserProfile = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    if payload.password is not None:
+        user.password_hash = _hash_password(payload.password)
+    if payload.first_name is not None:
+        user.first_name = payload.first_name
+    if payload.last_name is not None:
+        user.last_name = payload.last_name
+    db.commit()
+    db.refresh(user)
+    return _user_to_out(user, db)
+
+
+@users_router.post("/me/keys", response_model=APIKeyCreatedOut, status_code=201)
+def create_own_key(
+    payload: APIKeyCreateIn,
+    user: UserProfile = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    key = _create_api_key(db, user.id, payload.name, payload.expires_at)
+    return APIKeyCreatedOut(
+        id=key.id,
+        name=key.name,
+        prefix=key.prefix,
+        created_at=key.created_at,
+        last_used_at=key.last_used_at,
+        expires_at=key.expires_at,
+        is_active=key.is_active,
+        key=key.key,
+    )
+
+
+@users_router.get("/me/keys", response_model=list[APIKeyOut])
+def list_own_keys(
+    user: UserProfile = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    keys = db.query(APIKey).filter(APIKey.user_id == user.id).order_by(APIKey.created_at.desc()).all()
+    return [APIKeyOut.model_validate(k) for k in keys]
+
+
+@users_router.delete("/me/keys/{key_id}", status_code=204)
+def revoke_own_key(
+    key_id: int,
+    user: UserProfile = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    key = db.query(APIKey).filter(APIKey.id == key_id, APIKey.user_id == user.id).first()
+    if not key:
+        raise HTTPException(status_code=404, detail="API key not found.")
+    key.is_active = False
+    db.commit()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Admin-only user CRUD
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@users_router.post("/", response_model=UserOut, status_code=201)
+def create_user(
+    payload: UserCreateIn,
+    admin: UserProfile = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    if payload.role not in (UserRole.ADMIN, UserRole.NORMAL):
+        raise HTTPException(status_code=400, detail="Invalid role. Must be 'admin' or 'normal'.")
+    existing = db.query(UserProfile).filter(UserProfile.username == payload.username).first()
+    if existing:
+        raise HTTPException(status_code=409, detail="Username already exists.")
+
+    user = UserProfile(
+        username=payload.username,
+        password_hash=_hash_password(payload.password),
+        role=payload.role,
+        first_name=payload.first_name or "",
+        last_name=payload.last_name or "",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return _user_to_out(user, db)
+
+
+@users_router.get("/", response_model=UserListOut)
+def list_users(
+    offset: int = 0,
+    limit: int = 50,
+    admin: UserProfile = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    total = db.query(UserProfile).count()
+    users = db.query(UserProfile).offset(offset).limit(limit).all()
+    return UserListOut(
+        users=[_user_to_out(u, db) for u in users],
+        total=total,
+    )
+
+
+@users_router.get("/{user_id}", response_model=UserOut)
+def get_user(
+    user_id: int,
+    admin: UserProfile = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    user = db.query(UserProfile).filter(UserProfile.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found.")
+    return _user_to_out(user, db)
+
+
+@users_router.patch("/{user_id}", response_model=UserOut)
+def update_user(
+    user_id: int,
+    payload: UserUpdateIn,
+    admin: UserProfile = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    user = db.query(UserProfile).filter(UserProfile.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found.")
+    if payload.role is not None:
+        if payload.role not in (UserRole.ADMIN, UserRole.NORMAL):
+            raise HTTPException(status_code=400, detail="Invalid role.")
+        user.role = payload.role
+    if payload.password is not None:
+        user.password_hash = _hash_password(payload.password)
+    if payload.first_name is not None:
+        user.first_name = payload.first_name
+    if payload.last_name is not None:
+        user.last_name = payload.last_name
+    db.commit()
+    db.refresh(user)
+    return _user_to_out(user, db)
+
+
+@users_router.delete("/{user_id}", status_code=204)
+def delete_user(
+    user_id: int,
+    admin: UserProfile = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    user = db.query(UserProfile).filter(UserProfile.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found.")
+    # Soft-delete: deactivate all API keys
+    db.query(APIKey).filter(APIKey.user_id == user.id).update({"is_active": False})
+    db.commit()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Admin key management for any user
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@users_router.post("/{user_id}/keys", response_model=APIKeyCreatedOut, status_code=201)
+def create_user_key(
+    user_id: int,
+    payload: APIKeyCreateIn,
+    admin: UserProfile = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    user = db.query(UserProfile).filter(UserProfile.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found.")
+    key = _create_api_key(db, user.id, payload.name, payload.expires_at)
+    return APIKeyCreatedOut(
+        id=key.id,
+        name=key.name,
+        prefix=key.prefix,
+        created_at=key.created_at,
+        last_used_at=key.last_used_at,
+        expires_at=key.expires_at,
+        is_active=key.is_active,
+        key=key.key,
+    )
+
+
+@users_router.get("/{user_id}/keys", response_model=list[APIKeyOut])
+def list_user_keys(
+    user_id: int,
+    admin: UserProfile = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    user = db.query(UserProfile).filter(UserProfile.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found.")
+    keys = db.query(APIKey).filter(APIKey.user_id == user.id).order_by(APIKey.created_at.desc()).all()
+    return [APIKeyOut.model_validate(k) for k in keys]
+
+
+@users_router.delete("/{user_id}/keys/{key_id}", status_code=204)
+def revoke_user_key(
+    user_id: int,
+    key_id: int,
+    admin: UserProfile = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    key = db.query(APIKey).filter(APIKey.id == key_id, APIKey.user_id == user_id).first()
+    if not key:
+        raise HTTPException(status_code=404, detail="API key not found.")
+    key.is_active = False
+    db.commit()

--- a/platform/auth.py
+++ b/platform/auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import secrets
+from datetime import datetime, timezone, timedelta
 
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -14,12 +15,19 @@ from models.user import APIKey, UserProfile, UserRole
 
 bearer_scheme = HTTPBearer()
 
+# Debounce interval for last_used_at updates (avoid write on every request)
+_LAST_USED_DEBOUNCE = timedelta(minutes=1)
+
 
 def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
     db: Session = Depends(get_db),
 ) -> UserProfile:
-    """FastAPI dependency: validate Bearer token and return UserProfile."""
+    """FastAPI dependency: validate Bearer token and return UserProfile.
+
+    Supports both session tokens and named API keys.  Keys must be active
+    and not expired.  Updates ``last_used_at`` with 1-minute debounce.
+    """
     token = credentials.credentials
     api_key = db.query(APIKey).filter(APIKey.key == token).first()
     if not api_key:
@@ -27,6 +35,35 @@ def get_current_user(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid or missing API key.",
         )
+
+    # Check key is active
+    if not api_key.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="API key has been revoked.",
+        )
+
+    # Check expiration
+    if api_key.expires_at is not None:
+        now = datetime.now(timezone.utc)
+        expires = api_key.expires_at
+        if expires.tzinfo is None:
+            expires = expires.replace(tzinfo=timezone.utc)
+        if now > expires:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="API key has expired.",
+            )
+
+    # Debounced last_used_at update (best-effort, never blocks auth)
+    now = datetime.now(timezone.utc)
+    if api_key.last_used_at is None or (now - _ensure_tz(api_key.last_used_at)) > _LAST_USED_DEBOUNCE:
+        try:
+            api_key.last_used_at = now
+            db.commit()
+        except Exception:
+            db.rollback()
+
     user = db.query(UserProfile).filter(UserProfile.id == api_key.user_id).first()
     if not user:
         raise HTTPException(
@@ -34,6 +71,13 @@ def get_current_user(
             detail="User not found.",
         )
     return user
+
+
+def _ensure_tz(dt: datetime) -> datetime:
+    """Add UTC tzinfo if datetime is naive."""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
 
 
 def require_admin(

--- a/platform/cli/__main__.py
+++ b/platform/cli/__main__.py
@@ -35,7 +35,8 @@ def cmd_setup(args: argparse.Namespace) -> None:
         db.add(user)
         db.flush()
 
-        api_key = APIKey(user_id=user.id, key=str(uuid.uuid4()))
+        raw_key = str(uuid.uuid4())
+        api_key = APIKey(user_id=user.id, key=raw_key, name="default", prefix=raw_key[:8])
         db.add(api_key)
         db.commit()
 

--- a/platform/conftest.py
+++ b/platform/conftest.py
@@ -94,9 +94,11 @@ def user_profile(db):
 
 @pytest.fixture
 def api_key(db, user_profile):
+    import uuid as _uuid
     from models.user import APIKey
 
-    key = APIKey(user_id=user_profile.id)
+    raw = str(_uuid.uuid4())
+    key = APIKey(user_id=user_profile.id, key=raw, name="default", prefix=raw[:8])
     db.add(key)
     db.commit()
     db.refresh(key)

--- a/platform/models/user.py
+++ b/platform/models/user.py
@@ -46,7 +46,7 @@ class UserProfile(Base):
     totp_last_used_at: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     # Relationships
-    api_key: Mapped[APIKey | None] = relationship("APIKey", back_populates="user", uselist=False)
+    api_keys: Mapped[list[APIKey]] = relationship("APIKey", back_populates="user")
     credentials: Mapped[list] = relationship("BaseCredential", back_populates="user_profile")
     created_by_agent: Mapped[UserProfile | None] = relationship(
         "UserProfile", remote_side="UserProfile.id", foreign_keys=[created_by_agent_id]
@@ -61,13 +61,17 @@ class APIKey(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     user_id: Mapped[int] = mapped_column(
-        __import__("sqlalchemy").ForeignKey("user_profiles.id", ondelete="CASCADE"),
-        unique=True,
+        ForeignKey("user_profiles.id", ondelete="CASCADE"),
     )
     key: Mapped[str] = mapped_column(String(36), default=lambda: str(uuid.uuid4()), unique=True)
+    name: Mapped[str] = mapped_column(String(100), default="default")
+    prefix: Mapped[str] = mapped_column(String(8), default="")
     created_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
 
-    user: Mapped[UserProfile] = relationship("UserProfile", back_populates="api_key")
+    user: Mapped[UserProfile] = relationship("UserProfile", back_populates="api_keys")
 
     def __repr__(self):
-        return f"<APIKey for user_id={self.user_id}>"
+        return f"<APIKey '{self.name}' for user_id={self.user_id}>"

--- a/platform/schemas/users.py
+++ b/platform/schemas/users.py
@@ -1,0 +1,73 @@
+"""User and API key management schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+# ── User schemas ──────────────────────────────────────────────────────────────
+
+
+class UserCreateIn(BaseModel):
+    username: str
+    password: str
+    role: str = "normal"
+    first_name: str | None = None
+    last_name: str | None = None
+
+
+class UserUpdateIn(BaseModel):
+    role: str | None = None
+    password: str | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+
+
+class SelfUpdateIn(BaseModel):
+    password: str | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+
+
+class UserOut(BaseModel):
+    id: int
+    username: str
+    role: str
+    first_name: str
+    last_name: str
+    created_at: datetime
+    mfa_enabled: bool
+    key_count: int = 0
+
+    model_config = {"from_attributes": True}
+
+
+class UserListOut(BaseModel):
+    users: list[UserOut]
+    total: int
+
+
+# ── API Key schemas ───────────────────────────────────────────────────────────
+
+
+class APIKeyCreateIn(BaseModel):
+    name: str = Field(max_length=100)
+    expires_at: datetime | None = None
+
+
+class APIKeyOut(BaseModel):
+    id: int
+    name: str
+    prefix: str
+    created_at: datetime
+    last_used_at: datetime | None = None
+    expires_at: datetime | None = None
+    is_active: bool
+
+    model_config = {"from_attributes": True}
+
+
+class APIKeyCreatedOut(APIKeyOut):
+    key: str  # full key — shown only at creation

--- a/platform/tests/test_cli.py
+++ b/platform/tests/test_cli.py
@@ -85,7 +85,7 @@ class TestCLISetup:
         )
         cli_db.add(existing)
         cli_db.flush()
-        cli_db.add(APIKey(user_id=existing.id, key="existing-key"))
+        cli_db.add(APIKey(user_id=existing.id, key="existing-key", name="default", prefix="existing"))
         cli_db.commit()
 
         code, out, err = _run_cli(["setup", "--username", "another", "--password", "pass"])

--- a/platform/tests/test_rbac.py
+++ b/platform/tests/test_rbac.py
@@ -58,7 +58,9 @@ def admin_user(db):
 
 @pytest.fixture
 def admin_key(db, admin_user):
-    key = APIKey(user_id=admin_user.id)
+    import uuid as _uuid
+    raw = str(_uuid.uuid4())
+    key = APIKey(user_id=admin_user.id, key=raw, name="default", prefix=raw[:8])
     db.add(key)
     db.commit()
     db.refresh(key)
@@ -86,7 +88,9 @@ def normal_user(db):
 
 @pytest.fixture
 def normal_key(db, normal_user):
-    key = APIKey(user_id=normal_user.id)
+    import uuid as _uuid
+    raw = str(_uuid.uuid4())
+    key = APIKey(user_id=normal_user.id, key=raw, name="default", prefix=raw[:8])
     db.add(key)
     db.commit()
     db.refresh(key)

--- a/platform/tests/test_ws.py
+++ b/platform/tests/test_ws.py
@@ -106,6 +106,8 @@ class TestGlobalWsAuthenticate:
         from ws.global_ws import _authenticate
         mock_db = MagicMock()
         mock_key = MagicMock()
+        mock_key.is_active = True
+        mock_key.expires_at = None
         mock_db.query.return_value.filter.return_value.first.return_value = mock_key
 
         with patch("ws.global_ws.SessionLocal", return_value=mock_db):

--- a/platform/ws/global_ws.py
+++ b/platform/ws/global_ws.py
@@ -24,11 +24,21 @@ PONG_TIMEOUT = 10  # seconds
 
 
 def _authenticate(token: str) -> bool:
-    """Validate token against APIKey table. Returns True if valid."""
+    """Validate token against APIKey table. Returns True if valid, active, and not expired."""
+    from datetime import datetime, timezone
+
     db = SessionLocal()
     try:
         api_key = db.query(APIKey).filter(APIKey.key == token).first()
-        return api_key is not None
+        if not api_key or not api_key.is_active:
+            return False
+        if api_key.expires_at is not None:
+            expires = api_key.expires_at
+            if expires.tzinfo is None:
+                expires = expires.replace(tzinfo=timezone.utc)
+            if datetime.now(timezone.utc) > expires:
+                return False
+        return True
     finally:
         db.close()
 


### PR DESCRIPTION
## Summary

Implements #137 — User management API with multi-key API key system.

### Changes

- **APIKey model**: Migrated from 1:1 to many-to-one relationship with UserProfile. Added `name`, `prefix`, `last_used_at`, `expires_at`, `is_active` fields.
- **User CRUD** (admin-only): `POST/GET/PATCH/DELETE /api/v1/users/` — create, list, get, update, soft-delete users
- **API key management** (admin): `POST/GET/DELETE /api/v1/users/{id}/keys` — create, list, revoke keys for any user
- **Self-service**: `GET/PATCH /api/v1/users/me`, `POST/GET/DELETE /api/v1/users/me/keys` — own profile + key management
- **Auth flow**: `get_current_user` now checks `is_active` and `expires_at`, with debounced `last_used_at` tracking
- **Login**: Creates/rotates a named "session" key without touching other API keys
- **WebSocket auth**: Updated to check `is_active` and `expires_at`
- **Migration**: Alembic migration with SQLite batch mode, backfills prefix from existing keys

### Endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/users/me` | user | Own profile |
| PATCH | `/users/me` | user | Update own profile (password, name) |
| POST | `/users/me/keys` | user | Create own API key |
| GET | `/users/me/keys` | user | List own keys |
| DELETE | `/users/me/keys/{key_id}` | user | Revoke own key |
| POST | `/users/` | admin | Create user |
| GET | `/users/` | admin | List users (paginated) |
| GET | `/users/{user_id}` | admin | Get user details |
| PATCH | `/users/{user_id}` | admin | Update user |
| DELETE | `/users/{user_id}` | admin | Soft-delete (deactivate keys) |
| POST | `/users/{user_id}/keys` | admin | Create key for user |
| GET | `/users/{user_id}/keys` | admin | List user's keys |
| DELETE | `/users/{user_id}/keys/{key_id}` | admin | Revoke specific key |

### Tests

256 passed, 1 pre-existing failure (`test_unknown_channel_no_id` — unrelated to this PR).

Closes #137