### PR TITLE
fix: migration fails on fresh DB — unnamed SQLite unique constraint

### DIFF
--- a/platform/alembic/versions/c5d6e7f8a9b0_multi_key_api_key_management.py
+++ b/platform/alembic/versions/c5d6e7f8a9b0_multi_key_api_key_management.py
@@ -28,9 +28,12 @@ def upgrade() -> None:
     connection.execute(text("PRAGMA foreign_keys=OFF"))
 
     # SQLite requires batch mode to alter constraints.
-    # We use batch_alter_table to recreate the table without the unique
-    # constraint on user_id, and add new columns.
-    with op.batch_alter_table("api_keys") as batch_op:
+    # The initial migration creates UniqueConstraint('user_id') without a name,
+    # so we must pass naming_convention to let Alembic resolve it by convention.
+    naming_convention = {
+        "uq": "uq_%(table_name)s_%(column_0_name)s",
+    }
+    with op.batch_alter_table("api_keys", naming_convention=naming_convention) as batch_op:
         batch_op.add_column(sa.Column("name", sa.String(100), nullable=False, server_default="default"))
         batch_op.add_column(sa.Column("prefix", sa.String(8), nullable=False, server_default=""))
         batch_op.add_column(sa.Column("last_used_at", sa.DateTime(), nullable=True))


### PR DESCRIPTION
## Summary

E2E testing against the Docker image revealed a crash on first boot: the `c5d6e7f8a9b0` migration fails on a fresh database.

### Root Cause

The initial migration (`ee58ce0cf036`) creates `UniqueConstraint('user_id')` **without a name**. When `c5d6e7f8a9b0` calls `batch_op.drop_constraint("uq_api_keys_user_id")`, Alembic can't find it because SQLite auto-generated a different name.

This only affects fresh installs (Docker first boot, new deployments). Existing DBs where the constraint was already present work fine.

### Fix

Pass `naming_convention` to `batch_alter_table` so Alembic derives the constraint name from the column — matching `uq_api_keys_user_id` by convention.

### Verified

- `alembic upgrade head` on fresh SQLite DB: ✅ passes
- All 115 existing tests: ✅ pass