### PR TITLE
fix: use org LLM_API_KEY secret in E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Run full E2E
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.LLM_API_KEY }}
         run: ./e2e/run_smoke.sh plit-e2e:local
 
       - name: Container logs on failure


### PR DESCRIPTION
One-line fix: `secrets.ANTHROPIC_API_KEY` → `secrets.LLM_API_KEY` to use the org-level secret.