### PR TITLE
chore: mark changelog as v0.3.9

### DIFF
--- a/docs-site/docs/changelog.md
+++ b/docs-site/docs/changelog.md
@@ -4,7 +4,7 @@ All notable changes to Pipelit will be documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.3.9] - 2026-03-15
 
 ### Added
 


### PR DESCRIPTION
Rename [Unreleased] to [0.3.9] so the release workflow can extract notes for the GitHub Release.