### PR TITLE
fix: restore compatibility with mcp 2.0, deepagents 0.7, fastapi 0.141

### DIFF
--- a/platform/components/_agent_shared.py
+++ b/platform/components/_agent_shared.py
@@ -659,15 +659,15 @@ class SkillAwareBackend:
 
     # -- Routed methods (skill paths → filesystem, others → default) --------
 
-    def ls_info(self, path):
+    def ls(self, path):
         if self._is_skill_path(path):
-            return self._fs.ls_info(self._translate_to_host_path(path))
-        return self._default.ls_info(path)
+            return self._fs.ls(self._translate_to_host_path(path))
+        return self._default.ls(path)
 
-    async def als_info(self, path):
+    async def als(self, path):
         if self._is_skill_path(path):
-            return await self._fs.als_info(self._translate_to_host_path(path))
-        return await self._default.als_info(path)
+            return await self._fs.als(self._translate_to_host_path(path))
+        return await self._default.als(path)
 
     def read(self, file_path, offset=0, limit=2000):
         if self._is_skill_path(file_path):
@@ -793,7 +793,7 @@ def _make_skill_aware_backend(
         # FilesystemBackend instance) should be used directly.
         if isinstance(default_backend_or_factory, type):
             default = default_backend_or_factory(tool_runtime)
-        elif callable(default_backend_or_factory) and not hasattr(default_backend_or_factory, "ls_info"):
+        elif callable(default_backend_or_factory) and not hasattr(default_backend_or_factory, "ls"):
             default = default_backend_or_factory(tool_runtime)
         else:
             default = default_backend_or_factory

--- a/platform/mcp_server.py
+++ b/platform/mcp_server.py
@@ -11,12 +11,12 @@ from pathlib import Path
 from typing import Any
 
 import httpx
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 CONFIG_PATH = Path.home() / ".config" / "aichat-platform" / "config.json"
 BASE_URL = os.environ.get("PLATFORM_BASE_URL", "http://localhost:8000")
 
-mcp = FastMCP("aichat-platform")
+mcp = MCPServer("aichat-platform")
 
 
 # ── Platform HTTP client ─────────────────────────────────────────────────────

--- a/platform/requirements.txt
+++ b/platform/requirements.txt
@@ -1,4 +1,6 @@
-fastapi>=0.110
+# fastapi >=0.139 / starlette >=1.3 include routers lazily (app.routes holds
+# _IncludedRouter stubs until the route table is materialised).
+fastapi>=0.141
 uvicorn[standard]>=0.27
 sqlalchemy>=2.0
 alembic>=1.13
@@ -10,7 +12,9 @@ python-multipart>=0.0.7
 rq>=1.16
 redis>=5.0
 httpx>=0.27
-mcp>=1.0
+# mcp 2.0 replaced mcp.server.fastmcp.FastMCP with mcp.server.MCPServer —
+# capped so the next major can't silently break mcp_server.py again.
+mcp>=2.0,<3
 langchain>=1.0
 langgraph>=0.2
 langgraph-checkpoint-redis>=0.3
@@ -19,7 +23,9 @@ langchain-anthropic>=0.3
 langchain-openai>=0.3
 python-telegram-bot>=21.0
 honcho>=2.0
-deepagents>=0.4
+# deepagents 0.7 renamed the backend protocol's ls_info/als_info to ls/als
+# (SkillAwareBackend delegates to them) — capped: it breaks on minor bumps.
+deepagents>=0.7.6,<0.8
 requests>=2.31
 jinja2>=3.1
 pyotp>=2.9

--- a/platform/tests/test_app_import.py
+++ b/platform/tests/test_app_import.py
@@ -28,9 +28,14 @@ class TestAppSetup:
     @patch("main.engine")
     def test_routers_registered(self, mock_engine):
         from main import app
-        # Check some expected routes exist
-        route_paths = [r.path for r in app.routes if hasattr(r, "path")]
-        assert any("/api/" in p for p in route_paths)
+        # FastAPI >=0.139 / Starlette >=1.3 include routers lazily: the
+        # entries in app.routes are unmaterialised _IncludedRouter stubs
+        # (no .path) until the route table is finalised on first request.
+        # Inspecting app.routes directly therefore misses every /api/ route.
+        # app.openapi() forces materialisation and reflects the real route
+        # table — which is what this test actually means to assert.
+        api_paths = list(app.openapi().get("paths", {}).keys())
+        assert any("/api/" in p for p in api_paths)
 
 
 class TestLifespanSkillsDir:

--- a/platform/tests/test_components_db.py
+++ b/platform/tests/test_components_db.py
@@ -229,11 +229,29 @@ class TestIdentifyUser:
         assert result["user_id"] == "manual_user"
 
     def test_unknown_channel_no_id(self):
+        """An unrecognised channel with no user id falls back to 'unknown'.
+
+        Mocks the DB the same way the sibling channel tests do: without the
+        patch this hits the real SessionLocal, so the result depends on
+        whatever platform/db.sqlite3 happens to contain.
+        """
         fn = self._factory()
         state = {"trigger": {}, "node_outputs": {}}
-        result = fn(state)
-        # No channel_id → returns is_new
-        assert result["user_id"] is None
+        with patch("components.identify_user.SessionLocal") as mock_cls:
+            mock_cls.return_value = MagicMock()
+
+            mock_user = SimpleNamespace(canonical_id="unknown:unknown", total_conversations=0)
+            mock_memory = MagicMock()
+            mock_memory.get_or_create_user.return_value = mock_user
+            mock_memory.get_user_context.return_value = {}
+
+            with patch("components.identify_user.MemoryService", return_value=mock_memory):
+                result = fn(state)
+
+        mock_memory.get_or_create_user.assert_called_once_with(
+            channel="unknown", channel_id="unknown", display_name=None,
+        )
+        assert result["user_id"] == "unknown:unknown"
         assert result["is_new_user"] is True
 
     def test_node_outputs_override(self):

--- a/platform/tests/test_skill_node.py
+++ b/platform/tests/test_skill_node.py
@@ -443,19 +443,19 @@ class TestSkillAwareBackend:
         backend, _ = self._make_backend(["/home/user/skills"])
         assert backend._is_skill_path("/home/user/skills-extra") is False
 
-    def test_ls_info_routes_skill_path_to_filesystem(self):
+    def test_ls_routes_skill_path_to_filesystem(self):
         backend, default = self._make_backend(["/home/user/skills"])
-        with patch.object(backend._fs, "ls_info", return_value=[{"path": "/home/user/skills/web"}]) as fs_ls:
-            result = backend.ls_info("/home/user/skills")
+        with patch.object(backend._fs, "ls", return_value=[{"path": "/home/user/skills/web"}]) as fs_ls:
+            result = backend.ls("/home/user/skills")
             fs_ls.assert_called_once_with("/home/user/skills")
-            default.ls_info.assert_not_called()
+            default.ls.assert_not_called()
             assert result == [{"path": "/home/user/skills/web"}]
 
-    def test_ls_info_routes_non_skill_to_default(self):
+    def test_ls_routes_non_skill_to_default(self):
         backend, default = self._make_backend(["/home/user/skills"])
-        default.ls_info.return_value = [{"path": "/workspace/src"}]
-        result = backend.ls_info("/workspace")
-        default.ls_info.assert_called_once_with("/workspace")
+        default.ls.return_value = [{"path": "/workspace/src"}]
+        result = backend.ls("/workspace")
+        default.ls.assert_called_once_with("/workspace")
         assert result == [{"path": "/workspace/src"}]
 
     def test_read_routes_skill_path_to_filesystem(self):
@@ -612,10 +612,10 @@ class TestMakeSkillAwareBackend:
         """Factory wraps an existing backend instance directly."""
         from components._agent_shared import _make_skill_aware_backend, SkillAwareBackend
 
-        # Use a plain object with ls_info to simulate a backend instance
+        # Use a plain object with ls to simulate a backend instance
         # (MagicMock is always callable, so it would be treated as a factory)
         class FakeBackend:
-            def ls_info(self, path):
+            def ls(self, path):
                 return []
 
         existing_backend = FakeBackend()
@@ -643,7 +643,7 @@ class TestMakeSkillAwareBackend:
 
         # SandboxedShellBackend inherits from LocalShellBackend which is a SandboxBackendProtocol
         sandbox_backend = MagicMock(spec=SandboxedShellBackend)
-        sandbox_backend.ls_info = MagicMock()  # has ls_info → treated as instance
+        sandbox_backend.ls = MagicMock()  # has ls → treated as instance
 
         factory = _make_skill_aware_backend(sandbox_backend, ["/skills"])
         result = factory(MagicMock())
@@ -738,23 +738,23 @@ class TestSkillAwareBackendAsync:
         return backend, default
 
     @pytest.mark.asyncio
-    async def test_als_info_routes_skill_path(self):
+    async def test_als_routes_skill_path(self):
         backend, default = self._make_backend(["/home/user/skills"])
         with patch.object(
-            backend._fs, "als_info", new_callable=AsyncMock,
+            backend._fs, "als", new_callable=AsyncMock,
             return_value=[{"path": "/home/user/skills/web"}],
         ) as fs_als:
-            result = await backend.als_info("/home/user/skills")
+            result = await backend.als("/home/user/skills")
             fs_als.assert_called_once_with("/home/user/skills")
-            default.als_info.assert_not_called()
+            default.als.assert_not_called()
             assert result == [{"path": "/home/user/skills/web"}]
 
     @pytest.mark.asyncio
-    async def test_als_info_routes_non_skill(self):
+    async def test_als_routes_non_skill(self):
         backend, default = self._make_backend(["/home/user/skills"])
-        default.als_info = AsyncMock(return_value=[{"path": "/workspace/src"}])
-        result = await backend.als_info("/workspace")
-        default.als_info.assert_called_once_with("/workspace")
+        default.als = AsyncMock(return_value=[{"path": "/workspace/src"}])
+        result = await backend.als("/workspace")
+        default.als.assert_called_once_with("/workspace")
         assert result == [{"path": "/workspace/src"}]
 
     @pytest.mark.asyncio
@@ -1046,11 +1046,11 @@ class TestSkillAwareBackendTranslation:
             fs_read.assert_called_once_with("/home/user/skills/web/SKILL.md", 0, 2000)
             assert result == "# SKILL.md"
 
-    def test_ls_info_translates_sandbox_path(self):
+    def test_ls_translates_sandbox_path(self):
         backend, default = self._make_backend(
             ["/.skill_providers/code"],
             {"/.skill_providers/code": "/opt/skills/code"},
         )
-        with patch.object(backend._fs, "ls_info", return_value=[]) as fs_ls:
-            backend.ls_info("/.skill_providers/code")
+        with patch.object(backend._fs, "ls", return_value=[]) as fs_ls:
+            backend.ls("/.skill_providers/code")
             fs_ls.assert_called_once_with("/opt/skills/code")


### PR DESCRIPTION
Master no longer builds from a clean install. Every top-level pin was an unbounded floor (`mcp>=1.0`, `deepagents>=0.4`, `fastapi>=0.110`), and three upstream releases since March resolve to versions the code doesn't work with. A fresh venv on master gives **2,017 passed / 45 failed**; this PR takes it to **2,062 passed / 0 failed**.

CI has been green only because it last ran in March against the old resolutions.

## The three breakages

### 1. `mcp` 2.0 — MCP server dead at import
2.0 removed `mcp.server.fastmcp`; `FastMCP` is now `mcp.server.MCPServer`. `platform/mcp_server.py` failed at import, taking 40 tests and the MCP entry point with it. The rest of the surface is unchanged — `@mcp.tool()` still returns the undecorated function, `run()` still defaults to stdio — so the 17 tool definitions needed no edits.

### 2. `deepagents` 0.7 — skill discovery silently reading the wrong filesystem
0.7 unified the backend protocol's `ls_info`/`als_info` into `ls`/`als` (returning `LsResult`). `SkillAwareBackend` still overrode the old names, so `ls`/`als` fell through `__getattr__` to the default backend — usually the in-memory `StateBackend`.

`SkillsMiddleware` calls exactly four backend methods: `ls`, `als`, `download_files`, `adownload_files`. Two of the four were listing the wrong filesystem, so **on-disk skills were invisible to skill discovery, with no error raised anywhere**.

The same rename also broke the backend-vs-factory probe in `_make_skill_aware_backend` (`hasattr(x, "ls_info")` → always False), so already-instantiated backends were called as if they were factories.

### 3. `fastapi` 0.141 — lazy router inclusion
FastAPI >=0.139 / Starlette >=1.3 include routers lazily: `app.routes` holds unmaterialised `_IncludedRouter` stubs with no `.path` until the route table is finalised. Runtime routing is unaffected; only `test_routers_registered`'s introspection broke. Fixed by asserting against `app.openapi()` — kept byte-identical to the fix already on `feat/agentgateway-integration` so the two don't conflict on rebase.

## Also fixed

`test_unknown_channel_no_id` ran `identify_user` against the real `SessionLocal`, so its result depended on whatever `platform/db.sqlite3` contained. It passed on CI only because the empty DB raised and hit the generic exception fallback, which also returns `user_id=None` — and its premise was wrong anyway (an unrecognised channel defaults `channel_id` to `"unknown"`, so the "no channel_id" early return never fires). Now mocked like its sibling channel tests. It was also the only test writing to the dev database during a run.

## Pins

Floors alone would not have prevented any of this — the breakage came from *newer* releases. `mcp` and `deepagents`, which break on major and minor bumps respectively, are now capped; each pin carries a comment naming the change.

## Validation

- Full suite: **2,062 passed, 0 failed** (was 2,017 / 45)
- App boots: `/health` → 200 `{"status":"ok","version":"0.3.16","redis":true,"database":true}`; `/api/v1/workflows/` → 401, confirming lazy routes materialise and auth still gates them
- MCP server under 2.0: 17 tools registered, schemas generated from type hints, `call_tool("list_workflows")` dispatches and returns correct content
- Dev `platform/db.sqlite3` md5 identical before and after a full run

## Follow-up

**#193 needs these same fixes.** It branched in April and carries only the FastAPI one, so it will fail CI on mcp and deepagents until it is rebased on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)