### PR TITLE
fix(e2e): stop reporting a failed smoke run as success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,13 @@ jobs:
         working-directory: platform/frontend
         run: npm run build
 
+  e2e-harness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: e2e harness reports failures as failures
+        run: ./e2e/test_cleanup_exit_codes.sh
+
   version-check:
     runs-on: ubuntu-latest
     steps:

--- a/e2e/run_smoke.sh
+++ b/e2e/run_smoke.sh
@@ -35,13 +35,35 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 cleanup() {
+    # Capture the status that triggered this trap BEFORE running anything else.
+    # Under `set -e` the script aborts on the first failing command — a container
+    # that never boots, a missing docker, a failed migration — and lands here
+    # with no assertion having run. Reporting that as success (which this trap
+    # used to do, because FAIL was still 0) hid a permanently broken e2e-smoke
+    # job behind a green check.
+    local rc=$?
+
     echo ""
     echo "═══ Cleanup ═══"
     [ -n "$MOCK_PID" ] && kill "$MOCK_PID" 2>/dev/null && echo "  Stopped mock LLM server"
-    docker rm -f "$CONTAINER_NAME" 2>/dev/null && echo "  Removed container $CONTAINER_NAME"
+    if [ -n "$(docker ps -aq --filter "name=$CONTAINER_NAME" 2>/dev/null)" ]; then
+        echo "═══ Container logs (last 100 lines) ═══"
+        docker logs "$CONTAINER_NAME" 2>&1 | tail -100
+        docker rm -f "$CONTAINER_NAME" > /dev/null 2>&1 && echo "  Removed container $CONTAINER_NAME"
+    fi
     echo ""
     echo "═══ Results: $PASS passed, $FAIL failed ═══"
+
+    if [ "$rc" -ne 0 ]; then
+        echo "  ABORTED early (exit status $rc) — the suite did not run to completion"
+        exit "$rc"
+    fi
     [ "$FAIL" -gt 0 ] && exit 1
+    # A run that asserted nothing is not a pass.
+    if [ "$PASS" -eq 0 ]; then
+        echo "  NO ASSERTIONS RAN — failing rather than reporting a vacuous pass"
+        exit 1
+    fi
     exit 0
 }
 trap cleanup EXIT

--- a/e2e/test_cleanup_exit_codes.sh
+++ b/e2e/test_cleanup_exit_codes.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Regression guard for run_smoke.sh's exit status.
+#
+# run_smoke.sh reports its result from an EXIT trap. A trap that ends in a bare
+# `exit 0` overrides the status that fired it, so an abort under `set -e` — a
+# container that never boots, a missing docker, a failed migration — was
+# reported to CI as success with "0 passed, 0 failed". e2e-smoke was green for
+# months while asserting nothing.
+#
+# This drives the real cleanup(), extracted from run_smoke.sh, through every
+# path, invoked the way the script invokes it: as an EXIT trap fired by `set -e`.
+#
+# Usage: ./e2e/test_cleanup_exit_codes.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SMOKE="$SCRIPT_DIR/run_smoke.sh"
+FN="$(mktemp)"
+trap 'rm -f "$FN"' EXIT
+
+awk '/^cleanup\(\) \{/,/^\}/' "$SMOKE" > "$FN"
+if ! grep -q "^cleanup() {" "$FN" || [ "$(wc -l < "$FN")" -lt 5 ]; then
+    echo "FATAL: could not extract cleanup() from $SMOKE"
+    exit 1
+fi
+
+FAILED=0
+
+run_case() {
+    local desc="$1" abort_rc="$2" pass="$3" fail="$4" expected="$5"
+    local actual
+    actual=$(bash -c "
+        set -euo pipefail
+        MOCK_PID=''; CONTAINER_NAME='no-such-container-$$'
+        PASS=$pass; FAIL=$fail
+        source '$FN'
+        trap cleanup EXIT
+        (exit $abort_rc)   # non-zero aborts under set -e, firing the trap
+    " > /dev/null 2>&1; echo $?)
+
+    if [ "$actual" = "$expected" ]; then
+        printf '  PASS  %-50s exit=%s\n' "$desc" "$actual"
+    else
+        printf '  FAIL  %-50s exit=%s (expected %s)\n' "$desc" "$actual" "$expected"
+        FAILED=1
+    fi
+}
+
+echo "═══ run_smoke.sh cleanup() exit-status matrix ═══"
+#         description                                  abort  pass fail  expected
+run_case "all assertions passed"                           0     7    0    0
+run_case "some assertions failed"                          0     5    2    1
+run_case "no assertions ran"                               0     0    0    1
+run_case "aborted: container never booted"                 1     0    0    1
+run_case "aborted: docker missing"                       127     0    0  127
+run_case "aborted mid-run, some passes recorded"           2     4    0    2
+echo ""
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "FAIL: cleanup() can report a failed run as success"
+    exit 1
+fi
+echo "OK: every failure mode surfaces a non-zero exit status"


### PR DESCRIPTION
## `e2e-smoke` has been green while asserting nothing

Here is the complete smoke output from a run that GitHub reported as **success** — this is from today, and the July 4 run on #193 is identical:

```
═══ 1. Container Boot ═══
  Waiting for Pipelit API...
  Timed out waiting for http://localhost:8000/docs

═══ Cleanup ═══
  Stopped mock LLM server

═══ Results: 0 passed, 0 failed ═══
```

The container never boots. Zero of the seven checks run. Exit status 0.

### Why

`run_smoke.sh` reports from an EXIT trap that ended in a bare `exit 0`:

```bash
cleanup() {
    ...
    echo "═══ Results: $PASS passed, $FAIL failed ═══"
    [ "$FAIL" -gt 0 ] && exit 1
    exit 0            # <-- overrides the status that fired the trap
}
trap cleanup EXIT
```

Under `set -euo pipefail`, any abort fires the trap before an assertion has run, so `FAIL` is still `0` and the trap replaces the real status with `0`. It's not specific to the boot timeout — a missing docker, a failed migration, a bad image all land the same way.

Second-order effect: the workflow's `Container logs on failure` step is gated on `if: failure()`. Since the job "succeeded," it never fired — which is exactly why the boot failure has produced no diagnostic output in any run, and why this went unnoticed for months.

## The fix

`cleanup()` now captures `$?` first, re-raises it when the run aborted, and treats zero assertions as a failure. It also dumps the container's last 100 log lines before removal, so the boot failure is diagnosable from the job log no matter which step fails.

## Verified locally, both directions

Reproduced with the real script (docker absent locally, so the abort happens at `docker run` instead of the boot wait — same trap, same result):

```
EXIT CODE BEFORE FIX: 0      ← total failure reported as success
EXIT CODE AFTER FIX:  127    ← "ABORTED early (exit status 127)"
```

And the new `e2e/test_cleanup_exit_codes.sh` drives the real `cleanup()` through all six paths, invoked as the script invokes it — installed as an EXIT trap, fired by `set -e`:

| case | before | after |
|---|---|---|
| all assertions passed | 0 | **0** |
| some assertions failed | 1 | **1** |
| no assertions ran | 0 ❌ | **1** |
| aborted: container never booted | 0 ❌ | **1** |
| aborted: docker missing | 0 ❌ | **127** |
| aborted mid-run, some passes | 0 ❌ | **2** |

The first two rows matter as much as the rest: the fix must not manufacture false reds on a genuinely passing run. The guard is wired into CI as the `e2e-harness` job (~10s) and was checked in both directions — it passes against this fix and exits 1 against the pre-fix script.

## Result on this PR's own CI run

`e2e-harness` passes in 6s. `e2e-smoke` **fails — and for the first time it ran real assertions**:

```
═══ 1. Container Boot ═══        PASS  Container is running
                                 PASS  Pipelit API responds
                                 PASS  Gateway health OK
═══ 2. Authentication ═══        PASS  Login returns access_token
                                 PASS  Token length >= 32
═══ 3. User Management ═══       PASS  Create user returns ID
                                 PASS  List users returns >= 2
                                 PASS  Get user returns correct username
                                 PASS  Update user changes first_name
═══ 4. API Key Lifecycle ═══     PASS  Create API key returns key
                                 PASS  List API keys returns >= 1
                                 PASS  Revoke API key returns 200 or 204
═══ 5. Gateway Health ═══        PASS  Gateway health status OK
                                 PASS  Gateway has credentials synced
═══ 6. Chat Round-Trip ═══       PASS  Send message succeeds
                                 FAIL  Chat response received via WS
═══ 7. Frontend Serving ═══      PASS  Root URL returns 200
                                 PASS  HTML contains Pipelit title
                                 PASS  HTML contains React root div

═══ Results: 18 passed, 1 failed ═══
```

This corrects something I asserted earlier in this description: the container does **not** permanently fail to boot. On this run it came up in about 3 seconds and 18 of 19 checks passed. The boot timeouts in previous runs were intermittent — a slow cold start against a 90s window (45 x 2s) — not a hard failure. The old harness masked both the intermittent timeout *and* the persistent failure below.

The one real failure is the **chat round-trip**: `send` succeeds, but no response arrives over the WebSocket within 45s (send → gateway → Pipelit → RQ → mock LLM → WS). Container logs show the API serving every request cleanly through section 5, so the break is somewhere in the async delivery path or the mock-LLM wiring (`LLM_BASE_URL=http://host.docker.internal:9999`). That is a genuine finding this job was previously incapable of reporting, and it's the natural next investigation — separate from this PR.

Merging this makes `e2e-smoke` red on open PRs, including #193, until that chat round-trip is resolved. That is the accurate state of the world.
