### PR TITLE
fix(deepagents): pass a backend instance, not a factory (0.7 migration)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,6 +12,17 @@ on:
       - "platform/main.py"
       - "platform/cli/**"
       - "platform/ws/**"
+      # The execution path: a component or service change is exactly what breaks
+      # the chat round-trip (send -> gateway -> Pipelit -> RQ -> LLM -> WS), and
+      # unit tests mock the library boundaries where those breaks live. Omitting
+      # these meant the deepagents 0.7 backend regression could not trigger the
+      # one job that catches it.
+      - "platform/components/**"
+      - "platform/services/**"
+      - "platform/handlers/**"
+      - "platform/tasks/**"
+      - "platform/triggers/**"
+      - "platform/requirements.txt"
       - "e2e/**"
   push:
     tags:

--- a/platform/components/_agent_shared.py
+++ b/platform/components/_agent_shared.py
@@ -758,51 +758,51 @@ class SandboxedSkillAwareBackend(SkillAwareBackend):
 # We do this via class registration rather than direct inheritance to avoid
 # importing the protocol at class-definition time.
 try:
+    from deepagents.backends.protocol import BackendProtocol as _BP
     from deepagents.backends.protocol import SandboxBackendProtocol as _SBP
     SandboxBackendProtocol = _SBP  # re-export for test convenience
 
     # ABC.register() makes isinstance/issubclass checks pass without requiring
     # the class to actually inherit (virtual subclass).
     _SBP.register(SandboxedSkillAwareBackend)
+    # Register the plain wrapper too: deepagents 0.7 gates on
+    # isinstance(backend, BackendProtocol) when deciding whether a callable is a
+    # legal backend, and a wrapper that only duck-types would sit one refactor
+    # away from being rejected.  SandboxedSkillAwareBackend inherits this via
+    # SkillAwareBackend and is additionally registered as a sandbox backend above.
+    _BP.register(SkillAwareBackend)
 except ImportError:
     SandboxBackendProtocol = None  # type: ignore[assignment,misc]
 
 
 def _make_skill_aware_backend(
-    default_backend_or_factory,
+    default_backend,
     skill_paths: list[str],
     sandbox_to_host: dict[str, str] | None = None,
 ):
-    """Create a backend factory that wraps the default backend with skill-aware routing.
+    """Wrap *default_backend* with skill-aware routing, returning the instance.
 
-    The returned factory is compatible with ``create_deep_agent(backend=...)`` and
-    ``SkillsMiddleware(backend=...)`` — both accept a callable that takes a
-    ``ToolRuntime`` and returns a ``BackendProtocol``.
+    This returns an initialized backend, NOT a factory.  deepagents 0.7 removed
+    backend factories: ``FilesystemMiddleware`` requires a ``BackendProtocol``
+    instance and rejects any callable that is not one, so a factory closure here
+    made every ``deep_agent`` node with skill edges fail at construction with
+    ``TypeError: backend must be an initialized backend instance``.
 
-    When the resolved default backend is a ``SandboxBackendProtocol`` (i.e.
-    supports ``execute()``), returns a ``SandboxedSkillAwareBackend`` so that
-    the execute tool remains available.
+    The pre-0.7 factory also accepted a backend *class* or *factory function* and
+    called it with a ``ToolRuntime``.  Neither exists in 0.7 — ``StateBackend()``
+    now takes no arguments and callers pass instances — so those branches are
+    gone with the closure.
 
-    When *sandbox_to_host* is provided, ``SkillAwareBackend`` translates
-    sandbox paths (``/.skill_providers/X/...``) to host paths before reading.
+    When the wrapped backend is a ``SandboxBackendProtocol`` (i.e. supports
+    ``execute()``), returns a ``SandboxedSkillAwareBackend`` so the execute tool
+    remains available to the agent.
+
+    When *sandbox_to_host* is provided, ``SkillAwareBackend`` translates sandbox
+    paths (``/.skill_providers/X/...``) to host paths before reading.
     """
-
-    def factory(tool_runtime):
-        # Classes (like StateBackend) and factory functions need to be called
-        # with tool_runtime.  Already-instantiated backends (e.g. a
-        # FilesystemBackend instance) should be used directly.
-        if isinstance(default_backend_or_factory, type):
-            default = default_backend_or_factory(tool_runtime)
-        elif callable(default_backend_or_factory) and not hasattr(default_backend_or_factory, "ls"):
-            default = default_backend_or_factory(tool_runtime)
-        else:
-            default = default_backend_or_factory
-
-        if SandboxBackendProtocol is not None and isinstance(default, SandboxBackendProtocol):
-            return SandboxedSkillAwareBackend(default, skill_paths, sandbox_to_host=sandbox_to_host)
-        return SkillAwareBackend(default, skill_paths, sandbox_to_host=sandbox_to_host)
-
-    return factory
+    if SandboxBackendProtocol is not None and isinstance(default_backend, SandboxBackendProtocol):
+        return SandboxedSkillAwareBackend(default_backend, skill_paths, sandbox_to_host=sandbox_to_host)
+    return SkillAwareBackend(default_backend, skill_paths, sandbox_to_host=sandbox_to_host)
 
 
 def _publish_tool_status(

--- a/platform/components/_agent_shared.py
+++ b/platform/components/_agent_shared.py
@@ -719,7 +719,62 @@ class SkillAwareBackend:
                 results[default_indices[i]] = resp
         return results
 
-    # -- All other methods delegated via __getattr__ ------------------------
+    # -- Remaining protocol surface, delegated explicitly -------------------
+    #
+    # These could all be served by __getattr__ below, and were until deepagents
+    # 0.7.  They cannot be any more: 0.7 introspects the backend *class*, not the
+    # instance, and __getattr__ only answers instance lookups.  Two call sites:
+    #
+    #   protocol.py:928  _supports_delete()  -> type(backend).delete
+    #       AttributeError, uncaught, on every model call.  This is fatal.
+    #   protocol.py:876  _method_accepts_max_count() -> getattr(cls, "grep")
+    #       AttributeError, caught, logs a warning; grep's max_count cap is then
+    #       applied after the search instead of bounding it.
+    #
+    # Signatures mirror BackendProtocol exactly so that introspection sees what
+    # it expects — notably grep's keyword-only max_count.
+    #
+    # Routing note: only reads (ls/als, read/aread, download_files) are routed to
+    # the skill filesystem.  Skill directories are read-only providers, so writes
+    # and deletes go to the default backend, which is the pre-0.7 behaviour.
+
+    def write(self, file_path: str, content: str):
+        return self._default.write(file_path, content)
+
+    async def awrite(self, file_path: str, content: str):
+        return await self._default.awrite(file_path, content)
+
+    def edit(self, file_path: str, old_string: str, new_string: str, replace_all: bool = False):
+        return self._default.edit(file_path, old_string, new_string, replace_all)
+
+    async def aedit(self, file_path: str, old_string: str, new_string: str, replace_all: bool = False):
+        return await self._default.aedit(file_path, old_string, new_string, replace_all)
+
+    def delete(self, file_path: str):
+        return self._default.delete(file_path)
+
+    async def adelete(self, file_path: str):
+        return await self._default.adelete(file_path)
+
+    def glob(self, pattern: str, path: str | None = None):
+        return self._default.glob(pattern, path)
+
+    async def aglob(self, pattern: str, path: str | None = None):
+        return await self._default.aglob(pattern, path)
+
+    def grep(self, pattern: str, path: str | None = None, glob: str | None = None, *, max_count: int | None = None):
+        return self._default.grep(pattern, path, glob, max_count=max_count)
+
+    async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None, *, max_count: int | None = None):
+        return await self._default.agrep(pattern, path, glob, max_count=max_count)
+
+    def upload_files(self, files):
+        return self._default.upload_files(files)
+
+    async def aupload_files(self, files):
+        return await self._default.aupload_files(files)
+
+    # -- Anything else (id, custom attributes) delegated via __getattr__ -----
 
     def __getattr__(self, name):
         return getattr(self._default, name)

--- a/platform/tests/test_skill_node.py
+++ b/platform/tests/test_skill_node.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import tempfile
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -640,6 +642,80 @@ class TestMakeSkillAwareBackend:
         middleware = FilesystemMiddleware(backend=backend)
 
         assert middleware.backend is backend
+
+    def test_exposes_full_protocol_surface_on_the_class(self):
+        """Every BackendProtocol method must exist on the CLASS, not just the instance.
+
+        deepagents 0.7 introspects the backend class — `type(backend).delete`
+        (protocol.py `_supports_delete`) and `getattr(cls, "grep")`
+        (`_method_accepts_max_count`). `__getattr__` only answers instance
+        lookups, so methods left to it are invisible there: `_supports_delete`
+        raised AttributeError on every model call, which was fatal.
+        """
+        from deepagents.backends.protocol import BackendProtocol
+        from deepagents.backends.local_shell import LocalShellBackend
+        from components._agent_shared import _make_skill_aware_backend
+
+        wrapper = _make_skill_aware_backend(LocalShellBackend(root_dir="/tmp"), ["/skills"])
+
+        protocol_methods = [m for m in vars(BackendProtocol) if not m.startswith("_")]
+        missing = [m for m in protocol_methods if not hasattr(type(wrapper), m)]
+
+        assert not missing, f"not visible to class-level introspection: {missing}"
+
+    def test_class_level_capability_probes_match_wrapped_backend(self):
+        """The wrapper must not silently downgrade the backend's capabilities."""
+        from deepagents.backends.protocol import _method_accepts_max_count, _supports_delete
+        from deepagents.backends.local_shell import LocalShellBackend
+        from components._agent_shared import _make_skill_aware_backend
+
+        raw = LocalShellBackend(root_dir="/tmp")
+        wrapper = _make_skill_aware_backend(raw, ["/skills"])
+
+        assert _supports_delete(wrapper) == _supports_delete(raw)
+        assert _method_accepts_max_count(type(wrapper), "grep") == _method_accepts_max_count(type(raw), "grep")
+
+    def test_real_deep_agent_constructs_and_runs(self):
+        """A real deep agent built on the wrapper both constructs AND runs.
+
+        Covers both halves of the deepagents 0.7 breakage, each of which took
+        down every deep_agent node with skill edges in a different place:
+          - construction: FilesystemMiddleware rejected the factory closure
+          - model call:   _supports_delete() hit type(backend).delete
+
+        Construction alone is not enough — the second failure only appears once
+        the graph is invoked.
+        """
+        from langchain_core.language_models.fake_chat_models import FakeListChatModel
+        from deepagents import create_deep_agent
+        from deepagents.backends.local_shell import LocalShellBackend
+        from components._agent_shared import _make_skill_aware_backend
+
+        class ToolBindingFake(FakeListChatModel):
+            """Real chat models implement bind_tools; the stock fake does not."""
+
+            def bind_tools(self, tools, **kwargs):
+                return self
+
+        with tempfile.TemporaryDirectory() as tmp:
+            skills_dir = os.path.join(tmp, "skills", "demo")
+            os.makedirs(skills_dir)
+            with open(os.path.join(skills_dir, "SKILL.md"), "w") as fh:
+                fh.write("---\nname: demo\ndescription: demo skill\n---\nbody\n")
+
+            backend = _make_skill_aware_backend(
+                LocalShellBackend(root_dir=tmp), [os.path.join(tmp, "skills")],
+            )
+            agent = create_deep_agent(
+                model=ToolBindingFake(responses=["hello from the agent"]),
+                system_prompt="test",
+                backend=backend,
+                skills=[os.path.join(tmp, "skills")],
+            )
+
+            result = agent.invoke({"messages": [{"role": "user", "content": "hi"}]})
+
+        assert result["messages"][-1].content == "hello from the agent"
 
     def test_preserves_skill_paths(self):
         """Skill paths are passed through to SkillAwareBackend."""

--- a/platform/tests/test_skill_node.py
+++ b/platform/tests/test_skill_node.py
@@ -590,76 +590,84 @@ class TestSandboxedSkillAwareBackend:
 
 
 class TestMakeSkillAwareBackend:
-    """Tests for the _make_skill_aware_backend factory function."""
+    """Tests for _make_skill_aware_backend.
 
-    def test_factory_with_class_backend(self):
-        """Factory correctly instantiates a class-based backend (like StateBackend)."""
+    It returns an initialized backend instance, not a factory: deepagents 0.7
+    removed backend factories, and FilesystemMiddleware rejects any callable
+    that is not a BackendProtocol instance.
+    """
+
+    def test_wraps_instance_backend(self):
+        """The supplied backend instance is wrapped directly."""
         from components._agent_shared import _make_skill_aware_backend, SkillAwareBackend
 
-        class MockBackendClass:
-            def __init__(self, tool_runtime):
-                self.tool_runtime = tool_runtime
-
-        factory = _make_skill_aware_backend(MockBackendClass, ["/skills"])
-        runtime = MagicMock()
-        result = factory(runtime)
-
-        assert isinstance(result, SkillAwareBackend)
-        assert isinstance(result._default, MockBackendClass)
-        assert result._default.tool_runtime is runtime
-
-    def test_factory_with_instance_backend(self):
-        """Factory wraps an existing backend instance directly."""
-        from components._agent_shared import _make_skill_aware_backend, SkillAwareBackend
-
-        # Use a plain object with ls to simulate a backend instance
-        # (MagicMock is always callable, so it would be treated as a factory)
         class FakeBackend:
             def ls(self, path):
                 return []
 
         existing_backend = FakeBackend()
-        factory = _make_skill_aware_backend(existing_backend, ["/skills"])
-        runtime = MagicMock()
-        result = factory(runtime)
+        result = _make_skill_aware_backend(existing_backend, ["/skills"])
 
         assert isinstance(result, SkillAwareBackend)
         assert result._default is existing_backend
 
-    def test_factory_preserves_skill_paths(self):
-        """Factory passes skill paths through to SkillAwareBackend."""
+    def test_returns_instance_not_factory(self):
+        """The return value must be a backend instance, never a callable.
+
+        A callable here is precisely what deepagents 0.7 rejects, and it made
+        every deep_agent node with skill edges fail at construction.
+        """
+        from components._agent_shared import _make_skill_aware_backend, SkillAwareBackend
+
+        result = _make_skill_aware_backend(MagicMock(), ["/skills"])
+
+        assert isinstance(result, SkillAwareBackend)
+        assert not callable(result)
+
+    def test_accepted_by_deepagents_filesystem_middleware(self):
+        """The wrapper is accepted by the real deepagents middleware.
+
+        This is the assertion whose absence let the 0.7 breakage through: the
+        unit tests exercised our own factory contract and mocked out
+        create_deep_agent, so nothing ever checked what deepagents does with
+        what we hand it.
+        """
+        from deepagents.middleware.filesystem import FilesystemMiddleware
+        from deepagents.backends.state import StateBackend
+        from components._agent_shared import _make_skill_aware_backend
+
+        backend = _make_skill_aware_backend(StateBackend(), ["/skills"])
+        middleware = FilesystemMiddleware(backend=backend)
+
+        assert middleware.backend is backend
+
+    def test_preserves_skill_paths(self):
+        """Skill paths are passed through to SkillAwareBackend."""
         from components._agent_shared import _make_skill_aware_backend
 
         paths = ["/skills/web", "/skills/code"]
-        factory = _make_skill_aware_backend(MagicMock(), paths)
-        result = factory(MagicMock())
+        result = _make_skill_aware_backend(MagicMock(), paths)
 
         assert result._skill_paths == ["/skills/web", "/skills/code"]
 
-    def test_factory_returns_sandboxed_variant_for_sandbox_backend(self):
-        """Factory returns SandboxedSkillAwareBackend when default is SandboxBackendProtocol."""
+    def test_returns_sandboxed_variant_for_sandbox_backend(self):
+        """A SandboxBackendProtocol backend yields SandboxedSkillAwareBackend."""
         from components._agent_shared import _make_skill_aware_backend, SandboxedSkillAwareBackend
         from components.sandboxed_backend import SandboxedShellBackend
 
         # SandboxedShellBackend inherits from LocalShellBackend which is a SandboxBackendProtocol
         sandbox_backend = MagicMock(spec=SandboxedShellBackend)
-        sandbox_backend.ls = MagicMock()  # has ls → treated as instance
 
-        factory = _make_skill_aware_backend(sandbox_backend, ["/skills"])
-        result = factory(MagicMock())
+        result = _make_skill_aware_backend(sandbox_backend, ["/skills"])
 
         assert isinstance(result, SandboxedSkillAwareBackend)
 
-    def test_factory_returns_plain_variant_for_non_sandbox_backend(self):
-        """Factory returns plain SkillAwareBackend when default is NOT SandboxBackendProtocol."""
+    def test_returns_plain_variant_for_non_sandbox_backend(self):
+        """A non-sandbox backend yields the plain SkillAwareBackend."""
         from components._agent_shared import _make_skill_aware_backend, SkillAwareBackend, SandboxedSkillAwareBackend
+        from deepagents.backends.state import StateBackend
 
-        class FakeStateBackend:
-            def __init__(self, tool_runtime):
-                pass
-
-        factory = _make_skill_aware_backend(FakeStateBackend, ["/skills"])
-        result = factory(MagicMock())
+        result = _make_skill_aware_backend(StateBackend(), ["/skills"])
 
         assert isinstance(result, SkillAwareBackend)
         assert not isinstance(result, SandboxedSkillAwareBackend)


### PR DESCRIPTION
Completes the deepagents 0.7 migration started in #194. That PR fixed the `ls_info`/`als_info` → `ls`/`als` rename and stopped there; 0.7 also **removed backend factories**, and pinning `deepagents>=0.7.6` turned that second breakage from incidental into guaranteed.

## The failure

Found by the newly-honest `e2e-smoke` job (#195) — its first real run caught a runtime break that all 2,062 unit tests miss:

```
[Worker-65][Exec 52c3a958][Node deep_agent_1][ERROR] Unexpected error in execute_node_job
  File "platform/components/deep_agent.py", line 208, in deep_agent_factory
    agent = create_deep_agent(**agent_kwargs)
  File "deepagents/graph.py", line 753, in create_deep_agent
    FilesystemMiddleware(
TypeError: backend must be an initialized backend instance. Backend factories were
removed in deepagents 0.7; pass StateBackend(), CompositeBackend(...), or another
BackendProtocol instance instead.
```

`_make_skill_aware_backend()` returned a factory closure. The guard at `deepagents/middleware/filesystem.py:1660` is `callable(backend) and not isinstance(backend, BackendProtocol)`, and `BackendProtocol` is an `abc.ABC`, so a closure is `callable=True, isinstance=False` and trips it.

**Every `deep_agent` node with skill edges died at construction.** It fires on the *general-purpose subagent's* `FilesystemMiddleware` (`graph.py:753`), which is built before the main agent's — so it's unconditionally fatal for that path. `SkillsMiddleware` has no equivalent guard, which is why this was the only symptom.

Downstream effect: the node throws, the workflow produces no reply, nothing is delivered, and the e2e chat round-trip waits 45s for a WebSocket response that never comes. RQ still logs `Job OK`, which is its own small lie worth a look later.

## The fix

`_make_skill_aware_backend()` builds and returns the wrapper **instance**. The class/factory-detection branches went with the closure: they existed to pass a `ToolRuntime`, and 0.7 has none — `StateBackend()` takes no arguments and callers pass instances. In this codebase the argument was always an instance regardless, since `_build_backend()` returns a `SandboxedShellBackend`.

`SkillAwareBackend` is also registered as a `BackendProtocol` virtual subclass. Strictly it isn't required — `callable()` consults `type(obj).__call__` and so bypasses the instance-level `__getattr__`, leaving the isinstance arm unevaluated — but a wrapper that only duck-types sits one upstream refactor away from rejection.

## Why the tests didn't catch it

`test_skill_node.py` exercised *our own* factory contract and mocked `create_deep_agent`, so nothing ever checked what deepagents does with what we hand it. The new `test_accepted_by_deepagents_filesystem_middleware` closes that gap by constructing the real middleware with the real wrapper.

## Verification

Empirical, against the installed 0.7.6 — not just code reading:

- Old closure → reproduces the exact `TypeError`
- New instance → `FilesystemMiddleware(backend=...)` constructs, and `middleware.backend is` our wrapper
- The real CI path: `create_deep_agent(model=..., backend=SandboxedSkillAwareBackend(...), skills=[...])` → builds a `CompiledStateGraph`. **The line that failed in CI now succeeds.**
- `SandboxedSkillAwareBackend` is `isinstance` of both `BackendProtocol` and `SandboxBackendProtocol`, so `supports_execution()` stays true and the agent keeps its `execute` tool
- Full suite: **2,063 passed**

An independent agent adversarially reviewed the theory and the fix against the 0.7.6 source and confirmed both, including that `SkillsMiddleware.before_agent` loads `SKILL.md` through the wrapper and that `execute`/`id`/`ls`/`read` all delegate correctly.

The proof this matters is #193's `e2e-smoke`, which should go from 18/19 to 19/19 once this lands.

## Known follow-ups, deliberately not in this PR

Both were confirmed empirically during review; neither blocks this fix.

1. **`memory=` has the wrong semantics (silent).** `deep_agent.py:159-162` passes `memory=["filesystem"]` (+ `"todos"`) — 0.4 feature flags. In 0.7 `memory` is a list of memory *file paths* handed to `MemoryMiddleware(backend=..., sources=...)`. Those sources resolve to `file_not_found`, get skipped silently with no warning, and render `<agent_memory>(No memory loaded)</agent_memory>`. Consequences: **`enable_todos` is entirely dead** (0.7 has no `todos` parameter and never instantiates `TodoListMiddleware`), and there's a latent hazard — a file named `filesystem` or `todos` at the workspace root would be injected verbatim into the system prompt, while a *directory* by that name yields a non-`file_not_found` error and a hard `ValueError` on every run.
2. **`grep` loses its in-backend `max_count` bound.** `_method_accepts_max_count(type(backend), "grep")` (`protocol.py:872-887`) does `getattr` on the *class*, which `__getattr__` cannot serve → `AttributeError` → caught, logged with a traceback, returns `False`. The cap is then applied after the search instead of bounding it. Affects any `__getattr__`-delegating wrapper; fixing it means declaring `grep`/`glob` explicitly on `SkillAwareBackend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)