### PR TITLE
fix(credentials): support keyless local inference servers

### DIFF
--- a/platform/api/credentials.py
+++ b/platform/api/credentials.py
@@ -58,6 +58,23 @@ def _mask(value: str) -> str:
     return value[:4] + "****" + value[-4:]
 
 
+def _auth_headers(api_key: str | None) -> dict[str, str]:
+    """Bearer header for *api_key*, or no header at all when there is no key.
+
+    An empty key must mean *no* Authorization header, never an empty one:
+    httpx refuses to send the malformed ``"Bearer "`` and raises
+    ``LocalProtocolError: Illegal header value b'Bearer '`` when serializing the
+    request, so it never leaves the process.  That surfaced as a connection-test
+    failure for keyless local inference servers (llama.cpp, vLLM, LM Studio,
+    Ollama, MLX), which need no credentials and answer happily with no header.
+
+    The key is stripped first: a whitespace-only value is truthy in Python but
+    produces the same unsendable header, and pasting one into the form is easy.
+    """
+    key = (api_key or "").strip()
+    return {"Authorization": f"Bearer {key}"} if key else {}
+
+
 def _serialize_credential(cred: BaseCredential, db: Session) -> dict:
     data = {
         "id": cred.id,
@@ -423,7 +440,7 @@ def test_credential(
             base = llm.base_url.rstrip("/") if llm.base_url else "https://api.z.ai/api/paas/v4"
             resp = httpx.get(
                 f"{base}/models",
-                headers={"Authorization": f"Bearer {llm.api_key}"},
+                headers=_auth_headers(llm.api_key),
                 timeout=15,
             )
             if resp.status_code in (401, 403):
@@ -435,7 +452,7 @@ def test_credential(
             base_url = llm.base_url.rstrip("/") if llm.base_url else "https://api.openai.com/v1"
             resp = httpx.get(
                 f"{base_url}/models",
-                headers={"Authorization": f"Bearer {llm.api_key}"},
+                headers=_auth_headers(llm.api_key),
                 timeout=15,
             )
             if resp.status_code in (401, 403):
@@ -480,7 +497,7 @@ def list_credential_models(
     try:
         resp = httpx.get(
             f"{base_url}/models",
-            headers={"Authorization": f"Bearer {llm.api_key}"},
+            headers=_auth_headers(llm.api_key),
             timeout=15,
         )
         resp.raise_for_status()

--- a/platform/services/llm.py
+++ b/platform/services/llm.py
@@ -136,7 +136,13 @@ def create_llm_from_db(
             kwargs["model_kwargs"] = {"response_format": response_format}
         if credential.base_url:
             kwargs["base_url"] = credential.base_url
-        return SanitizedChatOpenAI(api_key=api_key, **kwargs)
+        # Local inference servers (llama.cpp, vLLM, LM Studio, Ollama, MLX) take
+        # any token or none, so a keyless credential is a legitimate setup here.
+        # The OpenAI SDK refuses to construct without one ("Missing credentials.
+        # Please pass an `api_key` ..."), so stand in a placeholder rather than
+        # failing a configuration that works.  A server that does check the token
+        # still rejects it, with its own error.
+        return SanitizedChatOpenAI(api_key=api_key or "not-needed", **kwargs)
 
     raise ValueError(f"Unsupported provider type: {provider_type}")
 

--- a/platform/tests/test_config.py
+++ b/platform/tests/test_config.py
@@ -289,10 +289,25 @@ def test_allowed_hosts_removed():
     assert not hasattr(Settings, "ALLOWED_HOSTS") or "ALLOWED_HOSTS" not in Settings.model_fields
 
 
-def test_sandbox_mode_default():
-    """Settings.SANDBOX_MODE defaults to 'auto'."""
-    s = Settings()
-    assert s.SANDBOX_MODE == "auto"
+def test_sandbox_mode_default(tmp_path, monkeypatch):
+    """With no conf.json, SANDBOX_MODE falls back to 'auto'.
+
+    Asserted through load_conf() in an isolated PIPELIT_DIR rather than through
+    Settings(), which binds its defaults from conf.json at import time.  Reading
+    the real config made this fail for any developer who had actually run
+    `cli setup` — it writes the detected mode (e.g. "bwrap") to
+    ~/.config/pipelit/conf.json, so running the platform broke its own test.
+    """
+    pipelit_dir = tmp_path / "pipelit"
+    pipelit_dir.mkdir(parents=True)
+    monkeypatch.setenv("PIPELIT_DIR", str(pipelit_dir))
+    monkeypatch.delenv("SANDBOX_MODE", raising=False)
+
+    conf = load_conf()
+
+    assert conf.sandbox_mode == "auto"
+    # Replicate how Settings constructs the default from conf.json
+    assert (conf.sandbox_mode or "auto") == "auto"
 
 
 def test_zombie_threshold_zero_from_conf(tmp_path, monkeypatch):

--- a/platform/tests/test_credentials_keyless.py
+++ b/platform/tests/test_credentials_keyless.py
@@ -1,0 +1,152 @@
+"""Tests for keyless LLM credentials — local inference servers.
+
+A local inference server (llama.cpp, vLLM, LM Studio, Ollama, MLX) needs no API
+key, so an `openai_compatible` credential with an empty `api_key` is a valid
+setup rather than a misconfiguration.  Two separate places used to reject it:
+
+  * the connection test sent a literal ``"Bearer "``, which httpx refuses to
+    transmit (``LocalProtocolError: Illegal header value b'Bearer '``), so the
+    request never left the process and the test reported a failure that had
+    nothing to do with the server;
+  * ``create_llm_from_db`` handed the empty string to the OpenAI SDK, which
+    raises ``OpenAIError: Missing credentials``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def app(db):
+    from main import app as _app
+    from database import get_db
+
+    def _override_get_db():
+        try:
+            yield db
+        finally:
+            pass
+
+    _app.dependency_overrides[get_db] = _override_get_db
+    yield _app
+    _app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_client(client, api_key):
+    client.headers["Authorization"] = f"Bearer {api_key.key}"
+    return client
+
+
+@pytest.fixture
+def keyless_credential(db, user_profile):
+    """An openai_compatible credential pointing at a local server, no API key."""
+    from models.credential import BaseCredential, LLMProviderCredential
+
+    base = BaseCredential(
+        user_profile_id=user_profile.id,
+        name="local inference",
+        credential_type="llm",
+    )
+    db.add(base)
+    db.flush()
+    llm = LLMProviderCredential(
+        base_credentials_id=base.id,
+        provider_type="openai_compatible",
+        api_key="",
+        base_url="http://192.168.0.73:8080/v1",
+    )
+    db.add(llm)
+    db.commit()
+    db.refresh(base)
+    return base
+
+
+class TestAuthHeaders:
+    def test_key_present_sends_bearer(self):
+        from api.credentials import _auth_headers
+
+        assert _auth_headers("sk-abc") == {"Authorization": "Bearer sk-abc"}
+
+    def test_empty_key_sends_no_header(self):
+        from api.credentials import _auth_headers
+
+        assert _auth_headers("") == {}
+
+    def test_none_key_sends_no_header(self):
+        from api.credentials import _auth_headers
+
+        assert _auth_headers(None) == {}
+
+    @pytest.mark.parametrize("key", ["", None, "  ", "sk-abc"])
+    def test_never_emits_a_token_less_bearer(self, key):
+        """No input may produce ``Bearer`` with nothing after it.
+
+        That is the malformed value httpx rejects at send time (it validates
+        when serializing the request, not when the Headers object is built), so
+        the guarantee has to hold here rather than being caught downstream.
+        """
+        from api.credentials import _auth_headers
+
+        header = _auth_headers(key).get("Authorization")
+
+        if header is not None:
+            assert header.startswith("Bearer ")
+            assert header[len("Bearer "):].strip(), f"empty token in {header!r}"
+
+
+class TestKeylessConnectionTest:
+    def test_test_endpoint_omits_authorization(self, auth_client, keyless_credential):
+        with patch("api.credentials.httpx.get") as mock_get:
+            mock_get.return_value = MagicMock(status_code=200, text="{}")
+            resp = auth_client.post(f"/api/v1/credentials/{keyless_credential.id}/test/")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        assert "Authorization" not in mock_get.call_args.kwargs["headers"]
+
+    def test_test_endpoint_targets_the_configured_base_url(self, auth_client, keyless_credential):
+        with patch("api.credentials.httpx.get") as mock_get:
+            mock_get.return_value = MagicMock(status_code=200, text="{}")
+            auth_client.post(f"/api/v1/credentials/{keyless_credential.id}/test/")
+
+        assert mock_get.call_args.args[0] == "http://192.168.0.73:8080/v1/models"
+
+
+class TestKeylessRuntimeClient:
+    def test_client_builds_without_an_api_key(self):
+        """The OpenAI SDK refuses to construct with an empty key; stand one in."""
+        from services.llm import create_llm_from_db
+
+        cred = SimpleNamespace(
+            provider_type="openai_compatible",
+            api_key="",
+            base_url="http://192.168.0.73:8080/v1",
+        )
+
+        llm = create_llm_from_db(cred, "some-local-model")
+
+        assert str(llm.openai_api_base) == "http://192.168.0.73:8080/v1"
+
+    def test_real_key_is_not_replaced(self):
+        from services.llm import create_llm_from_db
+
+        cred = SimpleNamespace(
+            provider_type="openai_compatible",
+            api_key="sk-real-key",
+            base_url="http://example.invalid/v1",
+        )
+
+        llm = create_llm_from_db(cred, "some-model")
+
+        assert llm.openai_api_key.get_secret_value() == "sk-real-key"


### PR DESCRIPTION
Adding a local inference server as a credential fails its connection test, and the error points at the server — which was never contacted.

Reported against an MLX server at `http://192.168.0.73:8080/v1`. The server was healthy throughout: `GET /v1/models` returns 200 with a full model list.

## Two independent bugs

An `openai_compatible` credential pointing at a local server (llama.cpp, vLLM, LM Studio, Ollama, MLX) has **no API key**, because those servers don't authenticate. That's a valid setup, and two separate places rejected it.

### 1. Connection test and model list

The header was built unconditionally:

```python
headers={"Authorization": f"Bearer {llm.api_key}"}
```

With an empty key that's the literal `"Bearer "`, and httpx refuses to serialize it:

```
no Authorization header                -> 200  {"object":"list","data":[...]}
Bearer <empty>  (what Pipelit sent)    -> LocalProtocolError: Illegal header value b'Bearer '
Bearer dummy                           -> 200  {"object":"list","data":[...]}
```

The request never left the process, and the blanket `except Exception` around the test surfaced it as a generic connection failure. Three call sites: the connection test, the model-list dropdown, and GLM.

### 2. Runtime

Even bypassing the test, running a workflow failed — `create_llm_from_db` handed the empty key to the OpenAI SDK:

```
OpenAIError: Missing credentials. Please pass an `api_key`, ... or set the `OPENAI_API_KEY` environment variable.
```

## The fix

`_auth_headers()` omits the header entirely when there's no key, rather than sending an empty one. The `openai_compatible` client stands in a placeholder token, since the SDK refuses to construct without one. A server that *does* check the token still rejects it — with its own error rather than ours.

The key is stripped before the emptiness check. A whitespace-only value is truthy in Python and produces the same unsendable header; a parametrised test found that case, and pasting into the form makes it easy to hit.

## Verification

Against the real MLX server, with a keyless credential:

- `GET /v1/models` → **200**, 4 models listed
- `create_llm_from_db(...).invoke(...)` → real completion returned
- Header shape: `sk-abc` → `{"Authorization": "Bearer sk-abc"}`; `""`, `None`, `"  "` → `{}`

11 new tests in `test_credentials_keyless.py` cover the header helper, the test endpoint (asserting no `Authorization` is sent and the configured `base_url` is used), and both runtime client paths. Full suite: **2,077 passed**.

## Second commit: an unrelated test-isolation bug found on the way

`test_sandbox_mode_default` asserted `Settings().SANDBOX_MODE == "auto"` while reading the developer's real `~/.config/pipelit/conf.json`. `cli setup` writes the detected mode there (`sandbox_mode: "bwrap"`), so **bootstrapping a local instance broke the test suite** — running the platform broke its own tests, and only on machines where someone had actually run it. CI never saw it, having no `conf.json`.

Now asserted through `load_conf()` with an isolated `PIPELIT_DIR`, matching `test_zombie_threshold_zero_from_conf`, which sidesteps `Settings` for the same reason. Same class of coupling as the `db.sqlite3` one fixed in #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)