### PR TITLE
feat(mailbox): show the operation on canvas, and give each one input fields

### DIFF
--- a/platform/frontend/src/features/workflows/components/NodeDetailsPanel.tsx
+++ b/platform/frontend/src/features/workflows/components/NodeDetailsPanel.tsx
@@ -56,6 +56,74 @@ function formatTimestamp(ts: string | undefined): string {
   }
 }
 
+type MailboxField = {
+  key: string
+  label: string
+  type: "text" | "number" | "boolean"
+  placeholder?: string
+  help?: string
+}
+
+/**
+ * The parameters each mailbox operation reads from extra_config.
+ *
+ * Data-driven rather than a block of conditionals per operation: the node
+ * carries eight operations and the set will grow, and this is the shape
+ * NodeTypeSpec.config_schema would take if anything consumed it yet.
+ *
+ * Text fields accept {{ }} expressions, which is how an address reaches a
+ * downstream node — so nothing here is validated as a literal.
+ */
+const MAILBOX_ADDRESS: MailboxField = {
+  key: "address", label: "Address", type: "text",
+  placeholder: "{{ create_mailbox_1.address }}",
+  help: "Use the address the service returned, never one rebuilt from the name.",
+}
+const MAILBOX_JWT: MailboxField = {
+  key: "jwt", label: "Mailbox JWT", type: "text",
+  placeholder: "{{ create_mailbox_1.jwt }}",
+  help: "Optional. Supplying it keeps the full-service admin secret out of this call.",
+}
+const MAILBOX_TIMEOUT: MailboxField = {
+  key: "timeout_seconds", label: "Timeout (seconds)", type: "number",
+  placeholder: "150", help: "Verification mail has been observed at 60-120s.",
+}
+
+const MAILBOX_OPERATION_FIELDS: Record<string, MailboxField[]> = {
+  create_mailbox: [
+    { key: "name", label: "Name", type: "text", placeholder: "(random, e2e-prefixed)",
+      help: "Alphanumeric only — the service silently strips everything else." },
+  ],
+  delete_mailbox: [
+    { key: "address_id", label: "Address ID", type: "text",
+      placeholder: "{{ create_mailbox_1.address_id }}",
+      help: "The numeric id, not the address. This is what revokes the mailbox JWT." },
+  ],
+  list_mails: [MAILBOX_ADDRESS, MAILBOX_JWT],
+  wait_for_mail: [
+    MAILBOX_ADDRESS, MAILBOX_JWT,
+    { key: "contains", label: "Body contains", type: "text",
+      help: "Optional. Without it the first message that arrives matches." },
+    MAILBOX_TIMEOUT,
+    { key: "poll_seconds", label: "Poll interval (seconds)", type: "number", placeholder: "2" },
+  ],
+  wait_for_verification_email: [MAILBOX_ADDRESS, MAILBOX_JWT, MAILBOX_TIMEOUT],
+  wait_for_reset_password_email: [MAILBOX_ADDRESS, MAILBOX_JWT, MAILBOX_TIMEOUT],
+  list_unknown_mails: [],
+  prune_mailboxes: [
+    { key: "prefix", label: "Prefix", type: "text", placeholder: "tmpe2e",
+      help: "Required, no default: this prefix is shared across repos and matches other suites' mailboxes." },
+    { key: "protect", label: "Protect (comma separated)", type: "text",
+      placeholder: "tmpe2e178623933674lfew@mcp.kiwi",
+      help: "Required to delete. Reconcile against portal-client/docs/funded-entity-handover.md first." },
+    { key: "older_than_days", label: "Only older than (days)", type: "number",
+      help: "Secondary guard. Measured: it cannot separate junk from the permanent fixtures." },
+    { key: "limit", label: "Scan limit", type: "number", placeholder: "100" },
+    { key: "dry_run", label: "Dry run", type: "boolean" },
+    { key: "confirm", label: "Confirm deletion", type: "boolean" },
+  ],
+}
+
 const MAILBOX_OPERATION_HELP: Record<string, string> = {
   create_mailbox: "Creates a disposable address. Emits address, address_id and a mailbox-scoped jwt.",
   wait_for_verification_email: "Polls for the confirmation mail, then extracts its token. Needs address; jwt optional but avoids using the admin secret.",
@@ -217,6 +285,21 @@ function NodeConfigPanel({ slug, node, workflow, onClose }: Props) {
   const [mailboxOperation, setMailboxOperation] = useState<string>(
     (node.config.extra_config?.operation as string) ?? "create_mailbox"
   )
+  const [mailboxParams, setMailboxParams] = useState<Record<string, string | boolean>>(() => {
+    const extra = (node.config.extra_config ?? {}) as Record<string, unknown>
+    const seeded: Record<string, string | boolean> = {}
+    for (const fields of Object.values(MAILBOX_OPERATION_FIELDS)) {
+      for (const f of fields) {
+        if (extra[f.key] === undefined) continue
+        seeded[f.key] = f.type === "boolean"
+          ? Boolean(extra[f.key])
+          : Array.isArray(extra[f.key]) ? (extra[f.key] as unknown[]).join(", ") : String(extra[f.key])
+      }
+    }
+    // dry_run defaults on: prune deletes real mailboxes on a shared instance
+    if (seeded.dry_run === undefined) seeded.dry_run = true
+    return seeded
+  })
   const [triggerIsActive, setTriggerIsActive] = useState(node.config.is_active ?? true)
   const [triggerPriority, setTriggerPriority] = useState<string>(node.config.priority?.toString() ?? "0")
   const [triggerConfig, setTriggerConfig] = useState(JSON.stringify(node.config.trigger_config ?? {}, null, 2))
@@ -355,6 +438,20 @@ function NodeConfigPanel({ slug, node, workflow, onClose }: Props) {
     }
     if (node.component_type === "mailbox_action") {
       parsedExtra = { ...parsedExtra, operation: mailboxOperation }
+      for (const f of MAILBOX_OPERATION_FIELDS[mailboxOperation] ?? []) {
+        const v = mailboxParams[f.key]
+        if (f.type === "boolean") {
+          parsedExtra[f.key] = Boolean(v)
+        } else if (typeof v === "string" && v.trim() !== "") {
+          // `protect` is a list; everything else is a scalar. Numbers stay
+          // strings when they carry a {{ }} expression rather than a literal.
+          parsedExtra[f.key] = f.key === "protect"
+            ? v.split(",").map((x) => x.trim()).filter(Boolean)
+            : f.type === "number" && !v.includes("{{") ? Number(v) : v
+        } else {
+          delete parsedExtra[f.key]
+        }
+      }
     }
     if (node.component_type === "merge") {
       parsedExtra = { ...parsedExtra, mode: mergeMode }
@@ -1489,9 +1586,33 @@ function NodeConfigPanel({ slug, node, workflow, onClose }: Props) {
                 ))}
               </SelectContent>
             </Select>
+            {(MAILBOX_OPERATION_FIELDS[mailboxOperation] ?? []).map((f) => (
+              <div key={f.key} className="space-y-1">
+                {f.type === "boolean" ? (
+                  <div className="flex items-center justify-between">
+                    <Label className="text-xs">{f.label}</Label>
+                    <Switch
+                      checked={Boolean(mailboxParams[f.key])}
+                      onCheckedChange={(v) => setMailboxParams((prev) => ({ ...prev, [f.key]: v }))}
+                    />
+                  </div>
+                ) : (
+                  <>
+                    <Label className="text-xs">{f.label}</Label>
+                    <Input
+                      className="text-xs h-7"
+                      value={String(mailboxParams[f.key] ?? "")}
+                      placeholder={f.placeholder}
+                      onChange={(e) => setMailboxParams((prev) => ({ ...prev, [f.key]: e.target.value }))}
+                    />
+                  </>
+                )}
+                {f.help && <p className="text-[10px] text-muted-foreground">{f.help}</p>}
+              </div>
+            ))}
             <p className="text-[10px] text-muted-foreground">
-              Parameters go in Extra Config, and accept {"{{ }}"} expressions — e.g.{" "}
-              {"{"}"address": "{"{{"} create_mailbox_1.address {"}}"}"{"}"}
+              Text fields accept {"{{ }}"} expressions. Anything not listed here can still be set
+              in Extra Config below.
             </p>
           </div>
         </>

--- a/platform/frontend/src/features/workflows/components/WorkflowCanvas.tsx
+++ b/platform/frontend/src/features/workflows/components/WorkflowCanvas.tsx
@@ -10,6 +10,7 @@ import {
   faPlay, faBug, faComments, faCircleNotch, faCircleCheck, faCircleXmark, faMinus,
   faTerminal, faUserPlus, faPlug, faFingerprint,
   faDatabase, faFloppyDisk, faIdCard,
+  faEnvelope, faEnvelopeOpenText,
   faRocket, faPenRuler, faCompass, faBrain, faGraduationCap,
   faSquareCheck, faFileCircleCheck,
 } from "@fortawesome/free-solid-svg-icons"
@@ -59,6 +60,8 @@ const NODE_STATUS_COLORS: Record<NodeStatus, string> = {
 }
 
 const COMPONENT_COLORS: Record<string, string> = {
+  mailbox_action: "#0ea5e9",
+  mailbox_parse: "#38bdf8",
   ai_model: "#3b82f6",
   agent: "#8b5cf6",
   deep_agent: "#7c3aed",
@@ -100,6 +103,8 @@ const COMPONENT_COLORS: Record<string, string> = {
 }
 
 const COMPONENT_ICONS: Record<string, IconDefinition> = {
+  mailbox_action: faEnvelope,
+  mailbox_parse: faEnvelopeOpenText,
   ai_model: faMicrochip, agent: faRobot, deep_agent: faBrain,
   categorizer: faTags, router: faCodeBranch, switch: faCodeBranch, extractor: faMagnifyingGlassChart,
   run_command: faTerminal,

--- a/platform/frontend/src/features/workflows/components/WorkflowCanvas.tsx
+++ b/platform/frontend/src/features/workflows/components/WorkflowCanvas.tsx
@@ -124,7 +124,7 @@ function getColor(type: string) {
   return COMPONENT_COLORS[type] || COMPONENT_COLORS.default
 }
 
-function WorkflowNodeComponent({ data, selected }: { data: { label: string; componentType: ComponentType; isEntryPoint: boolean; modelName?: string; providerType?: string; executionStatus?: NodeStatus; executable?: boolean; rules?: SwitchRule[]; enableFallback?: boolean; nodeOutput?: Record<string, unknown> }; selected?: boolean }) {
+function WorkflowNodeComponent({ data, selected }: { data: { label: string; componentType: ComponentType; isEntryPoint: boolean; modelName?: string; providerType?: string; executionStatus?: NodeStatus; executable?: boolean; rules?: SwitchRule[]; enableFallback?: boolean; nodeOutput?: Record<string, unknown>; operation?: string }; selected?: boolean }) {
   const iconColor = getColor(data.componentType)
   const isRunning = data.executionStatus === "running"
   const isWaiting = data.executionStatus === "waiting"
@@ -186,9 +186,17 @@ function WorkflowNodeComponent({ data, selected }: { data: { label: string; comp
         {COMPONENT_ICONS[data.componentType] && (
           <FontAwesomeIcon icon={COMPONENT_ICONS[data.componentType]} className="w-5 h-5 shrink-0" style={{ color: iconColor }} />
         )}
-        <div>
+        <div className="min-w-0">
           <div className="text-xs font-medium text-muted-foreground">{displayType}</div>
-          <div className="text-sm font-semibold">{isAiModel ? (data.modelName || "undefined") : displayLabel}</div>
+          {/* The label is a random suffix, so a node carrying an operation shows
+              that instead — otherwise every mailbox node looks alike on canvas.
+              Same treatment ai_model already gets with its model name. */}
+          <div className="text-sm font-semibold truncate">
+            {isAiModel ? (data.modelName || "undefined") : data.operation ? data.operation.replace(/_/g, " ") : displayLabel}
+          </div>
+          {data.operation && (
+            <div className="text-[10px] text-muted-foreground truncate">{displayLabel}</div>
+          )}
         </div>
       </div>
       {data.isEntryPoint && <div className="text-[10px] text-primary mt-1">Entry Point</div>}
@@ -440,7 +448,7 @@ export default function WorkflowCanvas({ slug, workflow, selectedNodeId, onSelec
       id: n.node_id,
       type: "workflowNode",
       position: { x: n.position_x, y: n.position_y },
-      data: { label: n.label || n.node_id, componentType: n.component_type, isEntryPoint: n.is_entry_point, modelName: n.config?.model_name || undefined, providerType, executionStatus: nodeStatuses[n.node_id], executable: nodeTypeRegistry?.[n.component_type]?.executable, rules: n.component_type === "switch" ? ((n.config?.extra_config?.rules as SwitchRule[]) ?? []) : undefined, enableFallback: n.component_type === "switch" ? Boolean(n.config?.extra_config?.enable_fallback) : false, nodeOutput: nodeOutputs[n.node_id] },
+      data: { label: n.label || n.node_id, componentType: n.component_type, isEntryPoint: n.is_entry_point, modelName: n.config?.model_name || undefined, providerType, executionStatus: nodeStatuses[n.node_id], executable: nodeTypeRegistry?.[n.component_type]?.executable, rules: n.component_type === "switch" ? ((n.config?.extra_config?.rules as SwitchRule[]) ?? []) : undefined, enableFallback: n.component_type === "switch" ? Boolean(n.config?.extra_config?.enable_fallback) : false, nodeOutput: nodeOutputs[n.node_id], operation: n.component_type === "mailbox_action" ? ((n.config?.extra_config?.operation as string) || "create_mailbox") : undefined },
       selected: n.node_id === selectedNodeId,
     }
   }), [workflow.nodes, selectedNodeId, credentialMap, nodeStatuses, nodeOutputs, nodeTypeRegistry])


### PR DESCRIPTION
Two usability gaps found by driving the mailbox nodes for real, both frontend-only.

## 1. The canvas couldn't tell mailbox nodes apart

A node displayed only its random id suffix, so eight nodes doing eight different things were indistinguishable. The **operation is now the prominent line**, with the id kept below in small text — the id still matters, because it is what an expression references (`{{ mailbox_action_ab12cd34.address }}`).

This follows the treatment `ai_model` already gets, where the model name replaces the label.

## 2. Parameters had to be hand-written as JSON

Every parameter went into the Extra Config textarea, with nothing indicating which keys an operation actually reads. Each operation now declares its own fields and the panel renders them:

| operation | fields |
|---|---|
| `create_mailbox` | name |
| `delete_mailbox` | address_id |
| `list_mails` | address, jwt |
| `wait_for_mail` | address, jwt, contains, timeout, poll interval |
| `wait_for_verification_email` / `wait_for_reset_password_email` | address, jwt, timeout |
| `list_unknown_mails` | — |
| `prune_mailboxes` | prefix, protect, older-than, limit, dry run, confirm |

The spec is data-driven rather than a conditional per operation — there are eight and the set will grow, and it is the shape `NodeTypeSpec.config_schema` would take if anything consumed that field yet.

### Details that matter more than they look

- **Number fields stay strings when they carry a `{{ }}` expression**, so a templated timeout is not coerced to `NaN`
- **`protect` splits on commas into a list**, which is what the component expects — a bare string would silently protect nothing, on the one operation where that is dangerous
- **`dry_run` seeds to true**, matching the component's own default, so a prune node is never armed merely by being created
- **An emptied field is deleted from `extra_config`** rather than written as `""`, so the component's defaults apply
- Help text carries the things that cost something to learn: alphanumeric-only names, using the returned address rather than a rebuilt one, and that the prune prefix is shared across repos

## Validation

The frontend has no test harness — `dev`/`build`/`lint`/`preview` only, no vitest — so this is verified by feeding the panel's exact save output through the real component:

- `wait_for_verification_email` extracted its token, with the timeout and scoped JWT passed through
- `prune_mailboxes` honoured the protect list and left the funded fixture untouched

Backend suite 2,140 passed. Frontend builds; lint unchanged at 14 pre-existing problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)