### PR TITLE
fix(canvas): stop the node title colliding with the status badge

### DIFF
--- a/platform/frontend/src/features/workflows/components/WorkflowCanvas.tsx
+++ b/platform/frontend/src/features/workflows/components/WorkflowCanvas.tsx
@@ -157,7 +157,7 @@ function WorkflowNodeComponent({ data, selected }: { data: { label: string; comp
   const showFallbackHandle = isSwitch && data.enableFallback
   return (
     <div
-      className={`relative px-3 py-2 rounded-lg border-2 border-muted-foreground/50 bg-card shadow-sm ${isFixedWidth ? "w-[250px]" : "min-w-[140px]"} ${selected ? "ring-2 ring-primary" : ""}`}
+      className={`relative px-3 py-2 rounded-lg border-2 border-muted-foreground/50 bg-card shadow-sm ${isFixedWidth ? "w-[250px]" : data.operation ? "min-w-[200px]" : "min-w-[140px]"} ${selected ? "ring-2 ring-primary" : ""}`}
     >
       {!isTrigger && !isSubComponent && <Handle type="target" position={Position.Left} className="!bg-muted-foreground !w-2 !h-2" />}
       {isSubComponent && <Handle type="source" position={Position.Top} id="sub-source" className="!bg-muted-foreground !w-2 !h-2 !rounded-none !rotate-45" />}
@@ -187,12 +187,12 @@ function WorkflowNodeComponent({ data, selected }: { data: { label: string; comp
           )}
         </div>
       )}
-      <div className="flex items-center gap-2">
+      <div className={`flex items-center gap-2 ${data.executable !== false && !isTool ? "pr-6" : ""}`}>
         {COMPONENT_ICONS[data.componentType] && (
           <FontAwesomeIcon icon={COMPONENT_ICONS[data.componentType]} className="w-5 h-5 shrink-0" style={{ color: iconColor }} />
         )}
         <div className="min-w-0">
-          <div className="text-xs font-medium text-muted-foreground">{displayType}</div>
+          <div className="text-xs font-medium text-muted-foreground truncate">{displayType}</div>
           {/* The label is a random suffix, so a node carrying an operation shows
               that instead — otherwise every mailbox node looks alike on canvas.
               Same treatment ai_model already gets with its model name. */}


### PR DESCRIPTION
The mailbox node's "Mailbox Action" type label ran underneath the execution status badge.

## Why widening alone would not have fixed it

The badge is absolutely positioned at `top-1.5 right-1.5` and **nothing reserved space for it**. The header row grew right up to the node edge, and the badge sat on top of whatever was there — at any width, for any type name long enough to reach it. A wider node just moves the point where it happens.

So the header row now reserves 24px on the right whenever that badge is shown (executable, non-tool — tool nodes put theirs bottom-right), and the type label truncates rather than running on. That fixes the same collision for **every** node with a long type name, not only this one.

Nodes carrying an operation also go from `min-w-[140px]` to `min-w-[200px]`, since they render three lines now and read cramped at the old width.

Frontend builds; lint unchanged at 14 pre-existing problems. Verified by construction rather than visually — the repo has no frontend test harness and no screenshot tooling wired up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)